### PR TITLE
Add remote support to Yggdrasil

### DIFF
--- a/BaUtils.h
+++ b/BaUtils.h
@@ -2,13 +2,22 @@
 #ifndef BAUTILS_H
 #define BAUTILS_H
 
-class BaflUtils
+class RFileUtilsObject
 {
 public:
 
-	static TInt deleteFile(const char *a_pccFileName);
+	virtual int deleteFile(const char *a_pccFileName) = 0;
 
-	static TInt RenameFile(const char *a_pccOldFullName, const char *a_pccNewFullName);
+	virtual int RenameFile(const char *a_pccOldFullName, const char *a_pccNewFullName) = 0;
+};
+
+class BaflUtils : public RFileUtilsObject
+{
+public:
+
+	int deleteFile(const char *a_pccFileName);
+
+	int RenameFile(const char *a_pccOldFullName, const char *a_pccNewFullName);
 };
 
 #endif /* ! BAUTILS_H */

--- a/Dir.cpp
+++ b/Dir.cpp
@@ -1037,7 +1037,7 @@ void RDir::close()
  * @return	KErrGeneral if some other unspecified error occurred
  */
 
-TInt RDir::read(TEntryArray *&a_rpoEntries, TDirSortOrder a_eSortOrder)
+TInt RDir::read(TEntryArray *&a_rpoEntries, enum TDirSortOrder a_eSortOrder)
 {
 	TInt RetVal;
 

--- a/Dir.h
+++ b/Dir.h
@@ -119,9 +119,33 @@ public:
 	void Sort(enum TDirSortOrder a_eSortOrder);
 };
 
-/* A class for scanning directories for directory and file entries */
+/**
+ * Interface for all directory scanning classes.
+ * This pure virtual base class defines the interface that all directory scanning classes will adhere to.  Instances
+ * of these classes can either be used directly, or obtained from RRemoteFactory::getDirObject().
+ */
 
-class RDir
+class RDirObject
+{
+protected:
+
+	TEntryArray		iEntries;		/**< Array of TEntry classes containing directory and file information */
+
+public:
+
+	virtual TInt open(const char *a_pccPattern) = 0;
+
+	virtual void close() = 0;
+
+	virtual TInt read(TEntryArray *&a_rpoEntries, enum TDirSortOrder a_eSortOrder = EDirSortNone) = 0;
+};
+
+/**
+ * A class for scanning directories for local directory and file entries.
+ * Instances of this class can be used to scan for file information on the local file system.
+ */
+
+class RDir : public RDirObject
 {
 private:
 
@@ -158,7 +182,6 @@ private:
 
 	TEntry			iSingleEntry;	/**< If a single entry is being examined, open() will populate this */
 	TBool			iSingleEntryOk;	/**< ETrue if the contents of iSingleEntry are valid, else EFalse */
-	TEntryArray		iEntries;		/**< Array of TEntry classes containing directory and file information */
 
 private:
 

--- a/File.cpp
+++ b/File.cpp
@@ -189,7 +189,8 @@ TInt RFile::Replace(const char *a_pccFileName, TUint a_uiFileMode)
 
 	/* Try to delete the file specified so that it can be recreated */
 
-	RetVal = BaflUtils::deleteFile(a_pccFileName);
+	BaflUtils BaflUtils;
+	RetVal = BaflUtils.deleteFile(a_pccFileName);
 
 	/* If the file was deleted successfully or if it didn't exist, continue on to create a new file */
 
@@ -368,7 +369,7 @@ TInt RFile::open(const char *a_pccFileName, TUint a_uiFileMode)
  * @return	Number of bytes read, if successful, otherwise KErrGeneral
  */
 
-TInt RFile::read(unsigned char *a_pucBuffer, TInt a_iLength) const
+TInt RFile::read(unsigned char *a_pucBuffer, TInt a_iLength)
 {
 	TInt RetVal;
 

--- a/File.h
+++ b/File.h
@@ -19,11 +19,36 @@ enum TFileMode
 };
 
 /**
- * A class for reading from or writing to files.
- * This class enables the creation, reading and writing of file in a platform independent manner.
+ * Interface for all file access classes.
+ * This pure virtual base class defines the interface that all file access classes will adhere to.  Instances
+ * of these classes can either be used directly, or obtained from RRemoteFactory::getFileObject().
  */
 
-class RFile
+class RFileObject
+{
+public:
+
+	virtual TInt Create(const char *a_fileName, TUint a_fileMode) = 0;
+
+	virtual TInt Replace(const char *a_fileName, TUint a_fileMode) = 0;
+
+	virtual TInt open(const char *a_fileName, TUint a_fileMode) = 0;
+
+	virtual TInt read(unsigned char *a_buffer, TInt a_length) = 0;
+
+	virtual TInt seek(TInt a_bytes) = 0;
+
+	virtual TInt write(const unsigned char *a_buffer, TInt a_length) = 0;
+
+	virtual void close() = 0;
+};
+
+/**
+ * A class for reading from or writing to local files.
+ * This class enables the local creation, reading and writing of file in a platform independent manner.
+ */
+
+class RFile : public RFileObject
 {
 private:
 
@@ -52,7 +77,7 @@ public:
 
 	TInt open(const char *a_pccFileName, TUint a_uiFileMode);
 
-	TInt read(unsigned char *a_pucBuffer, TInt a_iLength) const;
+	TInt read(unsigned char *a_pucBuffer, TInt a_iLength);
 
 	TInt seek(TInt a_iBytes);
 

--- a/FileInfo.cpp
+++ b/FileInfo.cpp
@@ -1,0 +1,19 @@
+
+#include "StdFuncs.h"
+#include "FileInfo.h"
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Saturday 25-Feb-2023 6:06 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+int RFileInfo::open(const char *a_fileName)
+{
+    return Utils::GetFileInfo(a_fileName, &m_fileInfo);
+}

--- a/FileInfo.h
+++ b/FileInfo.h
@@ -1,0 +1,29 @@
+
+#ifndef FILEINFO_H
+#define FILEINFO_H
+
+class RFileInfoObject
+{
+protected:
+
+	TEntry			m_fileInfo;		/**< Information about the remote file, in standard TEntry format */
+
+public:
+
+	virtual int open(const char *a_fileName) = 0;
+
+	TEntry *getFileInfo() { return &m_fileInfo; }
+
+	virtual void close() = 0;
+};
+
+class RFileInfo : public RFileInfoObject
+{
+public:
+
+	int open(const char *a_fileName);
+
+	void close() { };
+};
+
+#endif /* ! FILEINFO_H */

--- a/RemoteDir.cpp
+++ b/RemoteDir.cpp
@@ -1,0 +1,148 @@
+
+#include "StdFuncs.h"
+#include "RemoteFactory.h"
+#include "Yggdrasil/Commands.h"
+#include <memory>
+#include <string.h>
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Sunday 22-Jan-2023 11:08 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void CDir::execute()
+{
+}
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Sunday 22-Jan-2023 11:07 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void CDir::sendRequest()
+{
+	int32_t payloadSize = static_cast<int32_t>(strlen(m_directoryName) + 1);
+
+	m_command.m_size = payloadSize;
+	sendCommand();
+	m_socket->write(m_directoryName, payloadSize);
+	readResponse();
+}
+
+/**
+ * Opens an object for scanning.
+ * This function prepares to scan a file or directory.  The a_pccPattern parameter can
+ * refer to either a directory name, a single filename, a wildcard pattern or a combination
+ * thereof.  Examples are:
+ *
+ * ""\n
+ * "."\n
+ * "SomeDir"\n
+ * "SomeDir/"\n
+ * "*"\n
+ * "*.cpp"\n
+ * "SomeFile"\n
+ * "SomeDir/SomeFile.txt"\n
+ * "PROGDIR:"\n
+ *
+ * @date	Sunday 22-Jan-2023 10:41 am, Code HQ Tokyo Tsukuda
+ * @param	a_pccPattern	OS specific path and wildcard to scan
+ * @return	KErrNone if directory was opened successfully
+ * @return	KErrNotFound if the directory or file could not be opened for scanning
+ * @return	KErrNoMemory if not enough memory was available
+ * @return	KErrGeneral if some other unspecified error occurred
+ */
+
+int RRemoteDir::open(const char *a_pccPattern)
+{
+	RSocket socket;
+	int retVal = socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+
+	if (retVal == KErrNone)
+	{
+		socket.write(g_signature, SIGNATURE_SIZE);
+
+		CDir *handler = new CDir(&socket, ".");
+		handler->sendRequest();
+
+		if (handler->getResponse()->m_result == KErrNone)
+		{
+			const char *name;
+			uint32_t size;
+			TEntry *Entry;
+			TTime Now;
+
+			const unsigned char *payload = handler->getResponsePayload();
+			const unsigned char *payloadEnd = payload + handler->getResponse()->m_size;
+
+			Now.HomeTime();
+
+			/* Iterate through the file information in the payload and extract its contents.  Provided the payload */
+			/* is structured correctly, we could just check for it being ended by NULL terminator, but in the */
+			/* interest of safety, we'll also check that we haven't overrun the end */
+			while (payload < payloadEnd && *payload != '\0')
+			{
+				name = reinterpret_cast<const char *>(payload);
+				payload += strlen(name) + 1;
+				STREAM_INT(size, payload);
+				payload += sizeof(size);
+
+				if ((Entry = iEntries.Append(name)) != NULL)
+				{
+					Entry->Set(EFalse, EFalse, size, 0, Now.DateTime());
+					//Entry->iPlatformDate = iSingleEntry.iPlatformDate;
+				}
+
+				ASSERTM((payload < payloadEnd), "RRemoteDir::open => Payload contents do not match its size");
+			}
+		}
+		else
+		{
+			Utils::Error("RemoteDir: Received invalid response %d", handler->getResponse()->m_result);
+		}
+
+		delete handler;
+		socket.close();
+	}
+	else
+	{
+		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+	}
+
+	return retVal;
+}
+
+/**
+ * Scans a directory for file and directory entries.
+ * Scans a directory that has been prepared with RRemoteDir::open() and populates a list
+ * with all of the entries found.  This list is then returned to the calling client
+ * code.
+ *
+ * @date	Sunday 22-Jan-2023 10:42 am, Code HQ Tokyo Tsukuda
+ * @param	a_rpoEntries	Reference to a ptr into which to place a ptr to the
+ *							array of entries read by this function
+ * @param	a_eSortOrder	Enumeration specifying the order in which to sort the files.
+ *							EDirSortNone is used by default
+ * @return	KErrNone if successful
+ * @return	KErrNoMemory if not enough memory was available
+ * @return	KErrGeneral if some other unspecified error occurred
+ */
+
+int RRemoteDir::read(TEntryArray *&a_rpoEntries, enum TDirSortOrder a_eSortOrder)
+{
+	a_rpoEntries = &iEntries;
+
+	return KErrNone;
+}

--- a/RemoteDir.h
+++ b/RemoteDir.h
@@ -1,0 +1,31 @@
+
+#ifndef REMOTEDIR_H
+#define REMOTEDIR_H
+
+#include "Dir.h"
+#include "StdSocket.h"
+
+class CDir;
+class RRemoteFactory;
+
+/**
+ * A class for scanning directories for remote directory and file entries.
+ * Instances of this class can be used to scan for file information on the remote file system.
+ */
+
+class RRemoteDir : public RDirObject
+{
+	RRemoteFactory	*m_remoteFactory;
+
+public:
+
+	int open(const char *a_pccPattern);
+
+	void close() { }
+
+	int read(TEntryArray *&a_rpoEntries, enum TDirSortOrder a_eSortOrder = EDirSortNone);
+
+	void setFactory(RRemoteFactory *a_remoteFactory) { m_remoteFactory = a_remoteFactory; }
+};
+
+#endif /* ! REMOTEDIR_H */

--- a/RemoteFactory.h
+++ b/RemoteFactory.h
@@ -1,0 +1,93 @@
+
+#ifndef REMOTEFACTORY_H
+#define REMOTEFACTORY_H
+
+#include "RemoteDir.h"
+#include "RemoteFile.h"
+#include "RemoteFileInfo.h"
+#include "RemoteFileUtils.h"
+
+class RRemoteFactory
+{
+	RDir				m_dir;
+	RRemoteDir			m_remoteDir;
+	RFile				m_file;
+	RRemoteFile			m_remoteFile;
+	RFileInfo			m_fileInfo;
+	RRemoteFileInfo		m_remoteFileInfo;
+	BaflUtils			m_fileUtils;
+	RRemoteFileUtils	m_remoteFileUtils;
+	std::string			m_serverName;
+	int					m_serverPort;
+
+public:
+
+	RDirObject &getDirObject()
+	{
+		if (m_serverName.length() != 0)
+		{
+			m_remoteDir.setFactory(this);
+			return m_remoteDir;
+		}
+		else
+		{
+			return m_dir;
+		}
+	}
+
+	RFileObject &getFileObject()
+	{
+		if (m_serverName.length() != 0)
+		{
+			m_remoteFile.setFactory(this);
+			return m_remoteFile;
+		}
+		else
+		{
+			return m_file;
+		}
+	}
+
+	RFileInfoObject &getFileInfoObject()
+	{
+		if (m_serverName.length() != 0)
+		{
+			m_remoteFileInfo.setFactory(this);
+			return m_remoteFileInfo;
+		}
+		else
+		{
+			return m_fileInfo;
+		}
+	}
+
+	RFileUtilsObject &getFileUtilsObject()
+	{
+		if (m_serverName.length() != 0)
+		{
+			m_remoteFileUtils.setFactory(this);
+			return m_remoteFileUtils;
+		}
+		else
+		{
+			return m_fileUtils;
+		}
+	}
+
+	bool isRemote()
+	{
+		return m_serverName.length() != 0;
+	}
+
+	std::string &getServer() { return m_serverName; }
+
+	int &getPort() { return m_serverPort; }
+
+	void setConfig(const std::string &a_serverName, int a_port)
+	{
+		m_serverName = a_serverName;
+		m_serverPort = a_port;
+	}
+};
+
+#endif /* ! REMOTEFACTORY_H */

--- a/RemoteFile.cpp
+++ b/RemoteFile.cpp
@@ -1,0 +1,374 @@
+
+#include "StdFuncs.h"
+#include "RemoteFactory.h"
+#include "Yggdrasil/Commands.h"
+#include <memory>
+#include <string.h>
+
+#define TRANSFER_SIZE 1024
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Sunday 19-Feb-2023 9:15 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void CGet::execute()
+{
+}
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Sunday 19-Feb-2023 9:15 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void CGet::sendRequest()
+{
+	int32_t payloadSize = static_cast<int32_t>(strlen(m_fileName) + 1);
+
+	m_command.m_size = payloadSize;
+	sendCommand();
+	m_socket->write(m_fileName, payloadSize);
+	readResponse();
+}
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Saturday 25-Feb-2023 7:57 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void CSend::execute()
+{
+}
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Saturday 25-Feb-2023 7:57 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void CSend::sendRequest()
+{
+	int32_t payloadSize = static_cast<int32_t>(sizeof(SFileInfo) + strlen(m_fileName) + 1);
+
+	m_command.m_size = payloadSize;
+	sendCommand();
+
+	SFileInfo *fileInfo = reinterpret_cast<SFileInfo *>(new unsigned char [payloadSize]);
+
+	/* Initialise it with the file's name.  We won't include a timestamp in the packet, but will instead */
+	/* let the server just leave the timestamp at the file's creation time.  It doesn't really make sense */
+	/* to set a timestamp when saving a file from memory */
+	strcpy(fileInfo->m_fileName, m_fileName);
+
+	/* And finally send the payload and the file itself */
+	m_socket->write(fileInfo, payloadSize);
+
+	delete [] reinterpret_cast<unsigned char *>(fileInfo);
+}
+
+/**
+ * Creates a new file for writing.
+ * Creates a new file that can subsequently be used for writing operations.  If a file already
+ * exists with the same name then the function will fail.  The a_pccFileName parameter can additionally
+ * include a path to the file but the path must already exist.  It will not be created if it does
+ * not already exist.
+ *
+ * @date	Thursday 05-Jan-2023 6:50 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	a_pccFileName	Ptr to the name of the file to be created
+ * @param	a_uiFileMode	Mode in which to create the file.  Only for compatibility with Symbian
+ *							API and is ignored (but should be EFileWrite for consistency); one of
+ *							the @link TFileMode @endlink values
+ * @return	KErrNone if successful
+ * @return	KErrAlreadyExists if the file already exists
+ * @return	KErrInUse if the file or directory is in use
+ * @return	KErrNoMemory if not enough memory was available
+ * @return	KErrNotFound if the path is ok, but the file does not exist
+ * @return	KErrPathNotFound if the path to the file does not exist
+ * @return	KErrGeneral if some other unexpected error occurred
+ */
+
+int RRemoteFile::Create(const char *a_fileName, TUint a_fileMode)
+{
+	m_fileName = a_fileName;
+	m_readOffset = 0;
+
+	return KErrNone;
+}
+
+/**
+ * Creates a new file for writing, deleting any that previously exists.
+ * Creates a new file that can subsequently be used for writing operations.  If a file
+ * already exists with the same name then the function will replace it.  This function is
+ * a convenience wrapper around RRemoteFile::Create();  see that function for further details.
+ *
+ * @date	Thursday 05-Jan-2023 6:50 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	a_pccFileName	Ptr to the name of the file to be created
+ * @param	a_uiFileMode	Mode in which to create the file.  Only for compatibility with Symbian
+ *							API and is ignored (but should be EFileWrite for consistency); one of
+ *							the @link TFileMode @endlink values
+ * @return	KErrNone if successful
+ * @return	KErrAlreadyExists if the file already exists
+ * @return	KErrInUse if the file or directory is in use
+ * @return	KErrNoMemory if not enough memory was available
+ * @return	KErrNotFound if the path is ok, but the file does not exist
+ * @return	KErrPathNotFound if the path to the file does not exist
+ * @return	KErrGeneral if some other unexpected error occurred
+ */
+
+int RRemoteFile::Replace(const char *a_fileName, TUint a_fileMode)
+{
+	/* The remote server will always delete the file before creating it, so we can just directly call Create() */
+	return Create(a_fileName, a_fileMode);
+}
+
+/**
+ * Opens an existing file for reading and/or writing.
+ * Opens an existing file that can subsequently be used for reading or writing operations,
+ * or both.  The file can be opened using the file mode flags EFileRead, EFileWrite, or a
+ * logical combination of them both to elicit the desired behaviour.  If the file mode
+ * EFileWrite is specified then the file will also be writeable.  The a_pccFileName parameter can
+ * optionally specify a path to the file and can also be prefixed with an Amiga OS style "PROGDIR:"
+ * prefix.
+ *
+ * @date	Thursday 05-Jan-2023 6:50 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	a_pccFileName	Ptr to the name of the file to be opened
+ * @param	a_uiFileMode	Mode in which to open the file; one of the @link TFileMode @endlink values
+ * @return	KErrNone if successful
+ * @return	KErrInUse if the file is in use
+ * @return	KErrNoMemory if not enough memory was available
+ * @return	KErrNotFound if the path is ok, but the file does not exist
+ * @return	KErrPathNotFound if the path to the file does not exist
+ * @return	KErrGeneral if some other unexpected error occurred
+ */
+
+int RRemoteFile::open(const char *a_fileName, TUint a_fileMode)
+{
+	int retVal = m_socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+
+	if (retVal == KErrNone)
+	{
+		m_socket.write(g_signature, SIGNATURE_SIZE);
+
+		CGet *handler = new CGet(&m_socket, a_fileName);
+		handler->sendRequest();
+
+		if (handler->getResponse()->m_result == KErrNone)
+		{
+			readFromRemote();
+		}
+		else
+		{
+			Utils::Error("RemoteFile: Received invalid response %d", handler->getResponse()->m_result);
+		}
+
+		delete handler;
+		m_socket.close();
+	}
+	else
+	{
+		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+	}
+
+	return retVal;
+}
+
+/**
+ * Reads a number of bytes from the file.
+ * Reads a number of bytes from the file.  There must be sufficient data in the file to be
+ * able to satisfy the read request, or the function will fail.  It is safe to try and write
+ * 0 bytes.  In this case 0 will be returned.
+ *
+ * @pre		The file must be open
+ *
+ * @date	Thursday 05-Jan-2023 6:50 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	a_pucBuffer		Ptr to the buffer to read the data into
+ * @param	a_iLength		Number of bytes in the buffer to be read
+ * @return	Number of bytes read, if successful, otherwise KErrGeneral
+ */
+
+int RRemoteFile::read(unsigned char *a_buffer, int a_length)
+{
+	int retVal = KErrGeneral;
+
+	ASSERTM(m_fileBuffer, "RRemoteFile::read() => File is not open");
+
+	if (m_readOffset + a_length < m_fileBufferSize)
+	{
+		memcpy(a_buffer, m_fileBuffer + m_readOffset, a_length);
+		m_readOffset += a_length;
+		retVal = a_length;
+	}
+	else
+	{
+		memcpy(a_buffer, m_fileBuffer + m_readOffset, m_fileBufferSize - m_readOffset);
+		retVal = m_fileBufferSize - m_readOffset;
+		m_readOffset += m_fileBufferSize - m_readOffset;
+
+		if (retVal == 0)
+		{
+			retVal = KErrEof;
+		}
+	}
+
+	return retVal;
+}
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Thursday 05-Jan-2023 7:59 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void RRemoteFile::readFromRemote()
+{
+	uint32_t bytesRead = 0, bytesToRead, fileSize, size;
+
+	m_socket.read(&fileSize, sizeof(fileSize));
+	SWAP(&fileSize);
+
+	m_fileBuffer = new unsigned char[fileSize];
+
+	do
+	{
+		bytesToRead = ((fileSize - bytesRead) >= TRANSFER_SIZE) ? TRANSFER_SIZE : (fileSize - bytesRead);
+		size = m_socket.read(m_fileBuffer + bytesRead, bytesToRead);
+		bytesRead += size;
+	}
+	while (bytesRead < fileSize);
+
+	m_readOffset = 0;
+	m_fileBufferSize = fileSize;
+}
+
+/**
+ * Seeks to a specified position in the file.
+ * This is a basic seek function that will seek from the beginning of a file to the position
+ * passed in, that position being a number of bytes from the beginning of the file.
+ *
+ * @pre		The file must be open
+ *
+ * @date	Thursday 05-Jan-2023 9:12 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	a_iBytes		The number of bytes from the start of the file to which to seek
+ * @return	KErrNone if successful
+ * @return	KErrGeneral if the seek could not be performed
+ */
+
+int RRemoteFile::seek(int a_bytes)
+{
+	int retVal = KErrGeneral;
+
+	ASSERTM(m_fileBuffer, "RRemoteFile::seek() => File is not open");
+
+	if (a_bytes >= 0 && a_bytes < m_fileBufferSize)
+	{
+		retVal = KErrNone;
+		m_readOffset = a_bytes;
+	}
+
+	return retVal;
+}
+
+/**
+ * Writes a number of bytes to the file.
+ * Writes a number of bytes to the file.  The file must have been opened in a writeable mode,
+ * either by using RRemoteFile::open(EFileWrite), RRemoteFile::Replace() or RRemoteFile::Create().  In the
+ * latter two cases, files are always opened as writeable, regardless of the file mode passed in.
+ * It is safe to try and write 0 bytes.  In this case 0 will be returned
+ *
+ * @pre		The file must be open
+ *
+ * @date	Thursday 05-Jan-2023 6:50 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	a_pcucBuffer	Ptr to the buffer to be written to the file
+ * @param	a_iLength		Number of bytes in the buffer to be written
+ * @return	Number of bytes written, if successful, otherwise KErrGeneral
+ */
+
+int RRemoteFile::write(const unsigned char *a_buffer, int a_length)
+{
+	int retVal = KErrGeneral;
+	size_t endOffset = m_readOffset + a_length;
+
+	//ASSERTM((m_writeBuffer.size() > 0), "RRemoteFile::write() => File is not open");
+
+	if (endOffset > m_writeBuffer.size())
+	{
+		m_writeBuffer.resize(endOffset);
+	}
+
+	if (endOffset <= m_writeBuffer.size())
+	{
+		memcpy(m_writeBuffer.data() + m_readOffset, a_buffer, a_length);
+		m_readOffset += a_length; // TODO: CAW - Rename these
+		retVal = a_length;
+	}
+
+	return retVal;
+}
+
+/**
+ * Closes a file when access is no longer required.
+ * Closes a file that has been created for reading & writing, or opened for reading.
+ *
+ * @date	Thursday 05-Jan-2023 6:51 am, MK290 holiday apartment, Naha, Okinawa
+ */
+
+void RRemoteFile::close()
+{
+	delete [] m_fileBuffer;
+	m_fileBuffer = nullptr;
+
+	if (m_writeBuffer.size() > 0)
+	{
+		int retVal = m_socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+
+		if (retVal == KErrNone)
+		{
+			m_socket.write(g_signature, SIGNATURE_SIZE);
+
+			CSend *handler = new CSend(&m_socket, m_fileName.c_str());
+			handler->sendRequest();
+
+			int fileSize = static_cast<int>(m_writeBuffer.size());
+			SWAP(&fileSize);
+
+			m_socket.write(&fileSize, sizeof(fileSize));
+			m_socket.write(m_writeBuffer.data(), m_writeBuffer.size());
+
+			delete handler;
+		}
+		else
+		{
+			Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+		}
+	}
+
+	m_socket.close();
+}

--- a/RemoteFile.h
+++ b/RemoteFile.h
@@ -1,0 +1,52 @@
+
+#ifndef REMOTEFILE_H
+#define REMOTEFILE_H
+
+#include "File.h"
+#include "StdSocket.h"
+#include <string>
+#include <vector>
+
+class CGet;
+class CSend;
+class RRemoteFactory;
+
+/**
+ * A class for reading from or writing to remote files.
+ * This class enables the remote creation, reading and writing of file in a platform independent manner.
+ */
+
+class RRemoteFile : public RFileObject
+{
+	int				m_readOffset;
+	int				m_fileBufferSize;
+	unsigned char	*m_fileBuffer;
+	RRemoteFactory	*m_remoteFactory;
+	RSocket			m_socket;		/* Socket for communicating with remote RADRunner */
+	std::string		m_fileName;
+	std::vector<unsigned char>	m_writeBuffer;
+
+	void readFromRemote();
+
+public:
+
+	RRemoteFile() : m_readOffset(0), m_fileBufferSize(0), m_fileBuffer(nullptr) { }
+
+	int Create(const char *a_fileName, TUint a_fileMode);
+
+	int Replace(const char *a_fileName, TUint a_fileMode);
+
+	int open(const char *a_fileName, TUint a_fileMode);
+
+	int read(unsigned char *a_buffer, int a_length);
+
+	int seek(int a_bytes);
+
+	int write(const unsigned char *a_buffer, int a_length);
+
+	void close();
+
+	void setFactory(RRemoteFactory *a_remoteFactory) { m_remoteFactory = a_remoteFactory; }
+};
+
+#endif /* ! REMOTEFILE_H */

--- a/RemoteFileInfo.cpp
+++ b/RemoteFileInfo.cpp
@@ -1,0 +1,90 @@
+
+#include "StdFuncs.h"
+#include "RemoteFactory.h"
+#include "Yggdrasil/Commands.h"
+#include <string.h>
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Friday 24-Feb-2023 6:49 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void CFileInfo::execute()
+{
+}
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Friday 24-Feb-2023 6:50 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void CFileInfo::sendRequest()
+{
+	int32_t payloadSize = static_cast<int32_t>(strlen(m_fileName) + 1);
+
+	m_command.m_size = payloadSize;
+	sendCommand();
+	m_socket->write(m_fileName, payloadSize);
+	readResponse();
+}
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Friday 24-Feb-2023 6:47 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+int RRemoteFileInfo::open(const char *a_fileName)
+{
+	RSocket socket;
+	int retVal = socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+
+	if (retVal == KErrNone)
+	{
+		socket.write(g_signature, SIGNATURE_SIZE);
+
+		CFileInfo *handler = new CFileInfo(&socket, a_fileName);
+		handler->sendRequest();
+
+		if (handler->getResponse()->m_result == KErrNone)
+		{
+			/*const*/ SFileInfo* fileInfo = reinterpret_cast</*const*/ SFileInfo*>(handler->getResponsePayload());
+			SWAP64(&fileInfo->m_microseconds);
+			SWAP(&fileInfo->m_size);
+
+			TDateTime dateTime(fileInfo->m_microseconds);
+
+			m_fileInfo.Set(fileInfo->m_isDir, fileInfo->m_isLink, fileInfo->m_size, 0, dateTime);
+		}
+		else
+		{
+			Utils::Error("RemoteFileInfo: Received invalid response %d", handler->getResponse()->m_result);
+		}
+
+		delete handler;
+		socket.close();
+	}
+	else
+	{
+		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+	}
+
+	return retVal;
+}

--- a/RemoteFileInfo.h
+++ b/RemoteFileInfo.h
@@ -1,0 +1,24 @@
+
+#ifndef REMOTEFILEINFO_H
+#define REMOTEFILEINFO_H
+
+#include "FileInfo.h"
+#include "StdSocket.h"
+
+class CFileInfo;
+class RRemoteFactory;
+
+class RRemoteFileInfo : public RFileInfoObject
+{
+	RRemoteFactory	*m_remoteFactory;
+
+public:
+
+	int open(const char *a_fileName);
+
+	void close() { };
+
+	void setFactory(RRemoteFactory *a_remoteFactory) { m_remoteFactory = a_remoteFactory; }
+};
+
+#endif /* ! REMOTEFILEINFO_H */

--- a/RemoteFileUtils.cpp
+++ b/RemoteFileUtils.cpp
@@ -1,0 +1,168 @@
+
+#include "StdFuncs.h"
+#include "RemoteFactory.h"
+#include "Yggdrasil/Commands.h"
+#include "StdSocket.h"
+#include <string.h>
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Saturday 11-Mar-2023 5:53 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void CDelete::execute()
+{
+}
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Saturday 11-Mar-2023 5:53 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void CDelete::sendRequest()
+{
+	int32_t payloadSize = static_cast<int32_t>(strlen(m_fileName) + 1);
+
+	m_command.m_size = payloadSize;
+	sendCommand();
+	m_socket->write(m_fileName, payloadSize);
+	readResponse();
+}
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Saturday 11-Mar-2023 5:53 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void CRename::execute()
+{
+}
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Saturday 11-Mar-2023 5:53 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+void CRename::sendRequest()
+{
+	int32_t payloadSize = static_cast<int32_t>(strlen(m_oldName) + 1 + strlen(m_newName) + 1);
+
+	m_command.m_size = payloadSize;
+	sendCommand();
+	m_socket->write(m_oldName, strlen(m_oldName) + 1); // TODO: CAW
+	m_socket->write(m_newName, strlen(m_newName) + 1);
+	readResponse();
+}
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Wednesday 08-Mar-2023 7:02 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+int RRemoteFileUtils::deleteFile(const char *a_fileName)
+{
+	RSocket m_socket;
+
+	int retVal = m_socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+
+	if (retVal == KErrNone)
+	{
+		m_socket.write(g_signature, SIGNATURE_SIZE);
+
+		CDelete *handler = new CDelete(&m_socket, a_fileName);
+		handler->sendRequest();
+
+		if (handler->getResponse()->m_result == KErrNone)
+		{
+			// readFromRemote(); // TODO: CAW
+		}
+		else
+		{
+			// TODO: CAW - These should not use Utils::Error()
+			Utils::Error("deleteFile: Received invalid response %d", handler->getResponse()->m_result);
+		}
+
+		delete handler;
+		m_socket.close();
+	}
+	else
+	{
+		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+	}
+
+	return retVal;
+}
+
+/**
+ * Short description.
+ * Long multi line description.
+ *
+ * @pre		Some precondition here
+ *
+ * @date	Wednesday 08-Mar-2023 7:02 am, Code HQ Tokyo Tsukuda
+ * @param	Parameter		Description
+ * @return	Return value
+ */
+
+int RRemoteFileUtils::RenameFile(const char *a_oldFullName, const char *a_newFullName)
+{
+	RSocket m_socket;
+
+	int retVal = m_socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+
+	if (retVal == KErrNone)
+	{
+		m_socket.write(g_signature, SIGNATURE_SIZE);
+
+		CRename *handler = new CRename(&m_socket, a_newFullName, a_oldFullName); // TODO: CAW - Reversed parameters
+		handler->sendRequest();
+
+		if (handler->getResponse()->m_result == KErrNone)
+		{
+			// readFromRemote(); // TODO: CAW
+		}
+		else
+		{
+			Utils::Error("RenameFile: Received invalid response %d", handler->getResponse()->m_result);
+		}
+
+		delete handler;
+		m_socket.close();
+	}
+	else
+	{
+		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+	}
+
+	return retVal;
+}

--- a/RemoteFileUtils.h
+++ b/RemoteFileUtils.h
@@ -1,0 +1,22 @@
+
+#ifndef REMOTEFILEUTILS_H
+#define REMOTEFILEUTILS_H
+
+#include "BaUtils.h"
+
+class RRemoteFactory;
+
+class RRemoteFileUtils : public RFileUtilsObject
+{
+	RRemoteFactory	*m_remoteFactory;
+
+public:
+
+	int deleteFile(const char *a_fileName);
+
+	int RenameFile(const char *a_oldFullName, const char *a_newFullName);
+
+	void setFactory(RRemoteFactory *a_remoteFactory) { m_remoteFactory = a_remoteFactory; }
+};
+
+#endif /* ! REMOTEFILEUTILS_H */

--- a/StdFuncs.pro
+++ b/StdFuncs.pro
@@ -26,6 +26,7 @@ MOC_DIR = $$OBJECTS_DIR
 DEFINES -= UNICODE
 
 SOURCES += Args.cpp BaUtils.cpp Dir.cpp File.cpp Lex.cpp MungWall.cpp \
+    FileInfo.cpp RemoteDir.cpp RemoteFile.cpp RemoteFileInfo.cpp RemoteFileUtils.cpp Yggdrasil/Handler.cpp \
 	StdApplication.cpp StdCharConverter.cpp StdClipboard.cpp StdConfigFile.cpp StdCRC.cpp StdDialog.cpp StdFileRequester.cpp \
 	StdFont.cpp StdGadgets.cpp StdGadgetLayout.cpp StdGadgetSlider.cpp StdGadgetStatusBar.cpp StdGadgetTree.cpp \
 	StdImage.cpp StdPool.cpp StdRendezvous.cpp StdSocket.cpp StdStringList.cpp StdTextFile.cpp StdTime.cpp \

--- a/StdFuncs.vcxproj
+++ b/StdFuncs.vcxproj
@@ -206,8 +206,13 @@
     <ClCompile Include="BaUtils.cpp" />
     <ClCompile Include="Dir.cpp" />
     <ClCompile Include="File.cpp" />
+    <ClCompile Include="FileInfo.cpp" />
     <ClCompile Include="Lex.cpp" />
     <ClCompile Include="MungWall.cpp" />
+    <ClCompile Include="RemoteDir.cpp" />
+    <ClCompile Include="RemoteFile.cpp" />
+    <ClCompile Include="RemoteFileInfo.cpp" />
+    <ClCompile Include="RemoteFileUtils.cpp" />
     <ClCompile Include="StdApplication.cpp" />
     <ClCompile Include="StdCharConverter.cpp" />
     <ClCompile Include="StdClipboard.cpp" />
@@ -241,6 +246,11 @@
     <ClInclude Include="File.h" />
     <ClInclude Include="Lex.h" />
     <ClInclude Include="MungWall.h" />
+    <ClInclude Include="RemoteDir.h" />
+    <ClInclude Include="RemoteFactory.h" />
+    <ClInclude Include="RemoteFile.h" />
+    <ClInclude Include="RemoteFileInfo.h" />
+    <ClInclude Include="RemoteFileUtils.h" />
     <ClInclude Include="StdApplication.h" />
     <ClInclude Include="StdCharConverter.h" />
     <ClInclude Include="StdClipboard.h" />

--- a/StdGadgetTree.cpp
+++ b/StdGadgetTree.cpp
@@ -66,6 +66,8 @@ int CStdGadgetTree::construct(const std::string &a_title)
 
 	(void) a_title;
 
+	m_poParentLayout->Attach(this);
+
 #endif /* ! QT_GUI_LIB */
 
 	/* Attach the gadget to the parent window, if it was created successfully */

--- a/Yggdrasil/Handler.cpp
+++ b/Yggdrasil/Handler.cpp
@@ -2,8 +2,8 @@
 #include <StdFuncs.h>
 #include <BaUtils.h>
 #include <File.h>
-#include <StdSocket.h>
 #include "Commands.h"
+#include <string.h>
 
 #ifdef __unix__
 
@@ -14,15 +14,55 @@
 /* Number of bytes to be transferred per call to read() or write() */
 #define TRANSFER_SIZE 1024
 
+/* String versions of the commands supported by RADRunner.  These can be index by the TCommand enumeration */
 const char *g_commandNames[] =
 {
 	"version",
+	"delete",
 	"dir",
 	"execute",
+	"fileinfo",
 	"get",
+	"rename",
 	"send",
 	"shutdown"
 };
+
+/* Signature sent by the client when connecting, to identify it as a RADRunner client */
+const char g_signature[] = "RADR";
+
+int CHandler::getFileInformation(const char *a_fileName, SFileInfo *&a_fileInfo)
+{
+	int retVal;
+	TEntry entry;
+
+	/* Determine if the file exists and send the result to the remote client */
+	retVal = Utils::GetFileInfo(a_fileName, &entry);
+
+	/* If the file exists then send a response and a payload, containing the file's timestamp */
+	if (retVal == KErrNone)
+	{
+		/* Include the size of just the filename in the payload size */
+		int32_t payloadSize = static_cast<int32_t>(sizeof(SFileInfo) + strlen(entry.iName) + 1);
+
+		/* Allocate an SFileInfo structure of a size large enough to hold the file's name */
+		a_fileInfo = reinterpret_cast<SFileInfo*>(new unsigned char[payloadSize]);
+
+		/* Initialise it with the file's name and timestamp */
+		a_fileInfo->m_microseconds = entry.iModified.Int64();
+		SWAP64(&a_fileInfo->m_microseconds);
+		strcpy(a_fileInfo->m_fileName, entry.iName);
+
+		/* And other fields of interest */
+		a_fileInfo->m_isDir = entry.iIsDir;
+		a_fileInfo->m_isLink = entry.iIsLink;
+
+		a_fileInfo->m_size = entry.iSize;
+		SWAP(&a_fileInfo->m_size);
+	}
+
+	return retVal;
+}
 
 /**
  * Reads a file from a connected socket.
@@ -49,7 +89,8 @@ int CHandler::readFile(const char *a_fileName)
 
 	/* The Framework doesn't truncate a file if it already exists, so delete any existing file before continuing */
 	/* to avoid creating non working executables */
-	BaflUtils::deleteFile(a_fileName);
+	BaflUtils BaflUtils;
+	BaflUtils.deleteFile(a_fileName);
 
 	/* Now create a new empty file into which to write */
 	int retVal = file.Create(a_fileName, EFileWrite);
@@ -241,13 +282,16 @@ void CHandler::setFileInformation(const SFileInfo &a_fileInfo)
 {
 	int result;
 
-	/* Create a TEntry instance and use the given microseconds value to initialise its timestamp */
-	/* related members, so that it can be used to set the timestamp of the file just received */
-	TEntry entry(TDateTime(a_fileInfo.m_microseconds));
-
-	if ((result = Utils::setFileDate(a_fileInfo.m_fileName, entry)) != KErrNone)
+	if (a_fileInfo.m_microseconds != 0)
 	{
-		Utils::Error("Unable to set datestamp on file \"%s\" (Error %d)", a_fileInfo.m_fileName, result);
+		/* Create a TEntry instance and use the given microseconds value to initialise its timestamp */
+		/* related members, so that it can be used to set the timestamp of the file just received */
+		TEntry entry(TDateTime(a_fileInfo.m_microseconds));
+
+		if ((result = Utils::setFileDate(a_fileInfo.m_fileName, entry)) != KErrNone)
+		{
+			Utils::Error("Unable to set datestamp on file \"%s\" (Error %d)", a_fileInfo.m_fileName, result);
+		}
 	}
 
 #ifdef __amigaos__

--- a/makefile
+++ b/makefile
@@ -37,6 +37,7 @@ LIBRARY = $(OBJ)/libStdFuncs.a
 
 ifdef PREFIX
 	OBJECTS = $(OBJ)/AmiMenus.o $(OBJ)/Args.o $(OBJ)/BaUtils.o $(OBJ)/Dir.o $(OBJ)/File.o $(OBJ)/Lex.o $(OBJ)/MungWall.o \
+		$(OBJ)/FileInfo.o $(OBJ)/RemoteDir.o $(OBJ)/RemoteFile.o $(OBJ)/RemoteFileInfo.o $(OBJ)/RemoteFileUtils.o \
 		$(OBJ)/StdApplication.o $(OBJ)/StdCharConverter.o $(OBJ)/StdClipboard.o $(OBJ)/StdConfigFile.o $(OBJ)/StdCRC.o $(OBJ)/StdDialog.o \
 		$(OBJ)/StdFileRequester.o $(OBJ)/StdFont.o $(OBJ)/StdGadgets.o $(OBJ)/StdGadgetLayout.o $(OBJ)/StdGadgetSlider.o \
 		$(OBJ)/StdGadgetStatusBar.o $(OBJ)/StdGadgetTree.o $(OBJ)/StdImage.o $(OBJ)/StdPool.o $(OBJ)/StdRendezvous.o $(OBJ)/StdSocket.o \
@@ -53,6 +54,7 @@ ifdef PREFIX
 	endif
 else
 	OBJECTS = $(OBJ)/Args.o $(OBJ)/BaUtils.o $(OBJ)/StdCharConverter.o $(OBJ)/Dir.o $(OBJ)/File.o $(OBJ)/Lex.o $(OBJ)/MungWall.o \
+		$(OBJ)/FileInfo.o $(OBJ)/RemoteDir.o $(OBJ)/RemoteFile.o $(OBJ)/RemoteFileInfo.o $(OBJ)/RemoteFileUtils.o \
 		$(OBJ)/StdConfigFile.o $(OBJ)/StdCRC.o $(OBJ)/StdPool.o $(OBJ)/StdRendezvous.o $(OBJ)/StdSocket.o $(OBJ)/StdStringList.o \
 		$(OBJ)/StdTextFile.o $(OBJ)/StdTime.o $(OBJ)/StdWildcard.o $(OBJ)/Test.o $(OBJ)/Utils.o
 endif


### PR DESCRIPTION
This allows derivatives of the RDir and RFile classes, and the new RFileInfo class, to be used for accessing files remotely using RADRunner as a server.