### PR TITLE
Add remote support to Yggdrasil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .qmake.stash
+.qtc_clangd
 .vs
 .vscode
 *.user

--- a/Dir.h
+++ b/Dir.h
@@ -120,11 +120,32 @@ public:
 };
 
 /**
+ * Interface for all directory scanning classes.
+ * This pure virtual base class defines the interface that all directory scanning classes will adhere to.  Instances
+ * of these classes can either be used directly, or obtained from RRemoteFactory::getDirObject().
+ */
+
+class RDirObject
+{
+protected:
+
+	TEntryArray		m_entries;		/**< Array of TEntry classes containing directory and file information */
+
+public:
+
+	virtual TInt open(const char *a_pattern) = 0;
+
+	virtual void close() = 0;
+
+	virtual TInt read(TEntryArray *&a_entries, enum TDirSortOrder a_sortOrder = EDirSortNone) = 0;
+};
+
+/**
  * A class for scanning directories for local directory and file entries.
  * Instances of this class can be used to scan for file information on the local file system.
  */
 
-class RDir
+class RDir : public RDirObject
 {
 private:
 
@@ -161,7 +182,6 @@ private:
 
 	TEntry			iSingleEntry;	/**< If a single entry is being examined, open() will populate this */
 	TBool			iSingleEntryOk;	/**< ETrue if the contents of iSingleEntry are valid, else EFalse */
-	TEntryArray		m_entries;		/**< Array of TEntry classes containing directory and file information */
 
 private:
 

--- a/File.cpp
+++ b/File.cpp
@@ -80,7 +80,7 @@ int RFile::create(const char *a_fileName, TUint a_fileMode)
 			{
 				if (ChangeMode(CHANGE_FH, m_handle, EXCLUSIVE_LOCK) == 0)
 				{
-					Utils::info("RFile::open() => Unable to lock file for exclusive access");
+					Utils::info("RFile::create() => Unable to lock file for exclusive access");
 
 					RetVal = KErrInUse;
 
@@ -200,12 +200,10 @@ int RFile::replace(const char *a_fileName, TUint a_fileMode)
 
 /**
  * Opens an existing file for reading and/or writing.
- * Opens an existing file that can subsequently be used for reading or writing operations,
- * or both.  The file can be opened using the file mode flags EFileRead, EFileWrite, or a
- * logical combination of them both to elicit the desired behaviour.  If the file mode
- * EFileWrite is specified then the file will also be writeable.  The a_fileName parameter can
- * optionally specify a path to the file and can also be prefixed with an Amiga OS style "PROGDIR:"
- * prefix.
+ * Opens an existing file that can subsequently be used for reading or writing operations, or both.
+ * The file can be opened using the file mode flags EFileRead, EFileWrite, or a logical combination
+ * of them both to elicit the desired behaviour.  The a_fileName parameter can optionally include a
+ * path to the file and can also be prefixed with an Amiga OS style "PROGDIR:" prefix.
  *
  * @date	Friday 02-Jan-2009 8:57 pm
  * @param	a_fileName		Ptr to the name of the file to be opened

--- a/File.h
+++ b/File.h
@@ -19,11 +19,36 @@ enum TFileMode
 };
 
 /**
- * A class for reading from or writing to local files.
- * This class enables the local creation, reading and writing of file in a platform independent manner.
+ * Interface for all file access classes.
+ * This pure virtual base class defines the interface that all file access classes will adhere to.  Instances
+ * of these classes can either be used directly, or obtained from RRemoteFactory::getFileObject().
  */
 
-class RFile
+class RFileObject
+{
+public:
+
+	virtual int create(const char *a_fileName, TUint a_fileMode) = 0;
+
+	virtual int replace(const char *a_fileName, TUint a_fileMode) = 0;
+
+	virtual int open(const char *a_fileName, TUint a_fileMode) = 0;
+
+	virtual int read(unsigned char *a_buffer, int a_length) = 0;
+
+	virtual int seek(int a_bytes) = 0;
+
+	virtual int write(const unsigned char *a_buffer, int a_length) = 0;
+
+	virtual void close() = 0;
+};
+
+/**
+ * A class for reading from or writing to local files.
+ * This class enables the local creation, reading and writing of files in a platform independent manner.
+ */
+
+class RFile : public RFileObject
 {
 private:
 

--- a/FileUtils.cpp
+++ b/FileUtils.cpp
@@ -74,8 +74,8 @@ int RFileUtils::deleteFile(const char *a_fileName)
 
 /**
  * Obtains information about a given local file or directory.
- * Wrapper method that enables local operation of the @link Utils::GetFileInfo @endlink method.
- * See @link Utils::GetFileInfo @endlink for more detailed information.
+ * Wrapper method that enables local operation of the @link Utils::GetFileInfo() @endlink method.
+ * See @link Utils::GetFileInfo() @endlink for more detailed information.
  *
  * @pre		Pointer to filename passed in must not be NULL
  * @pre		Pointer to TEntry structure passed in must not be NULL
@@ -88,6 +88,9 @@ int RFileUtils::deleteFile(const char *a_fileName)
 
 int RFileUtils::getFileInfo(const char *a_fileName, TEntry *a_entry)
 {
+	ASSERTM((a_entry != NULL), "RFileUtils::getFileInfo() => Pointer to filename passed in must not be NULL");
+	ASSERTM((a_entry != NULL), "RFileUtils::getFileInfo() => TEntry structure passed in must not be NULL");
+
 	return Utils::GetFileInfo(a_fileName, a_entry);
 }
 

--- a/FileUtils.h
+++ b/FileUtils.h
@@ -4,7 +4,29 @@
 
 /** @file */
 
-class RFileUtils
+/**
+ * Interface for all file object manipulation classes.
+ * This pure virtual base class defines the interface that all file object manipulation classes will adhere to.
+ * Instances of these classes can either be used directly, or obtained from RRemoteFactory::getFileUtilsObject().
+ */
+
+class RFileUtilsObject
+{
+public:
+
+	virtual int deleteFile(const char *a_fileName) = 0;
+
+	virtual int getFileInfo(const char *a_fileName, TEntry *a_entry) = 0;
+
+	virtual int renameFile(const char *a_oldFullName, const char *a_newFullName) = 0;
+};
+
+/**
+ * A class for performing miscellaneous local file operations.
+ * Instances of this class can be used to delete, rename and query files and directories on the local file system.
+ */
+
+class RFileUtils : public RFileUtilsObject
 {
 public:
 

--- a/RemoteDir.cpp
+++ b/RemoteDir.cpp
@@ -1,0 +1,130 @@
+
+#include "StdFuncs.h"
+#include "RemoteFactory.h"
+#include "Yggdrasil/Commands.h"
+#include <memory>
+#include <string.h>
+
+/**
+ * Sends a directory listing to the remote client.
+ * This command is not required for the remote directory implementation, but must be present.
+ *
+ * @date	Sunday 22-Jan-2023 11:08 am, Code HQ Tokyo Tsukuda
+ */
+
+void CDir::execute()
+{
+}
+
+/**
+ * Requests a directory listing on the remote server.
+ * Requests the remote server list the contents of the specified directory.  The name of the directory
+ * to be listed is passed in as the payload.  If "" or "." is passed in, the contents of the current
+ * directory will be listed.
+ *
+ * @date	Sunday 22-Jan-2023 11:07 am, Code HQ Tokyo Tsukuda
+ */
+
+void CDir::sendRequest()
+{
+	int32_t payloadSize = static_cast<int32_t>(strlen(m_directoryName) + 1);
+
+	m_command.m_size = payloadSize;
+	sendCommand();
+	m_socket->write(m_directoryName, payloadSize);
+	readResponse();
+}
+
+/**
+ * Opens a remote object for scanning.
+ * This function prepares to scan a file or directory.  The a_pattern parameter can refer to either a
+ * directory name, a single filename, a wildcard pattern or a combination thereof.
+ *
+ * @date	Sunday 22-Jan-2023 10:41 am, Code HQ Tokyo Tsukuda
+ * @param	a_pattern		OS specific path and wildcard to scan
+ * @return	KErrNone if successful, otherwise one of the system errors
+ */
+
+int RRemoteDir::open(const char *a_pattern)
+{
+	(void) a_pattern;
+
+	RSocket socket;
+	int retVal = socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+
+	if (retVal == KErrNone)
+	{
+		socket.write(g_signature, SIGNATURE_SIZE);
+
+		CDir *handler = new CDir(&socket, ".");
+		handler->sendRequest();
+
+		if (handler->getResponse()->m_result == KErrNone)
+		{
+			const char *name;
+			uint32_t size;
+			TEntry *Entry;
+			TTime Now;
+
+			const unsigned char *payload = handler->getResponsePayload();
+			const unsigned char *payloadEnd = payload + handler->getResponse()->m_size;
+
+			Now.HomeTime();
+
+			/* Iterate through the file information in the payload and extract its contents.  Provided the payload */
+			/* is structured correctly, we could just check for it being ended by NULL terminator, but in the */
+			/* interest of safety, we'll also check that we haven't overrun the end */
+			while (payload < payloadEnd && *payload != '\0')
+			{
+				name = reinterpret_cast<const char *>(payload);
+				payload += strlen(name) + 1;
+				STREAM_INT(size, payload);
+				payload += sizeof(size);
+
+				if ((Entry = m_entries.Append(name)) != NULL)
+				{
+					Entry->Set(EFalse, EFalse, size, 0, Now.DateTime());
+				}
+
+				ASSERTM((payload < payloadEnd), "RRemoteDir::open => Payload contents do not match its size");
+			}
+		}
+		else
+		{
+			Utils::Error("RemoteDir: Received invalid response %d", handler->getResponse()->m_result);
+
+			retVal = handler->getResponse()->m_result;
+		}
+
+		delete handler;
+		socket.close();
+	}
+	else
+	{
+		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+	}
+
+	return retVal;
+}
+
+/**
+ * Scans a remote directory for file and directory entries.
+ * Scans a directory that has been prepared with RRemoteDir::open() and populates a list with all of
+ * the entries found.  This list is then returned to the calling client code.
+ *
+ * @date	Sunday 22-Jan-2023 10:42 am, Code HQ Tokyo Tsukuda
+ * @param	a_entries		Reference to a ptr into which to place a ptr to the array of entries read
+ *							by this function
+ * @param	a_sortOrder		Enumeration specifying the order in which to sort the files.  EDirSortNone
+ * 							is used by default
+ * @return	KErrNone is always returned, as this method cannot fail
+ */
+
+int RRemoteDir::read(TEntryArray *&a_entries, enum TDirSortOrder a_sortOrder)
+{
+	(void) a_sortOrder;
+
+	a_entries = &m_entries;
+
+	return KErrNone;
+}

--- a/RemoteDir.h
+++ b/RemoteDir.h
@@ -1,0 +1,35 @@
+
+#ifndef REMOTEDIR_H
+#define REMOTEDIR_H
+
+/** @file */
+
+#include "Dir.h"
+#include "StdSocket.h"
+
+class CDir;
+class RRemoteFactory;
+
+/**
+ * A class for scanning directories for remote directory and file entries.
+ * Instances of this class can be used to scan for file information on the remote file system.
+ */
+
+class RRemoteDir : public RDirObject
+{
+	RRemoteFactory	*m_remoteFactory;	/**< Pointer to the remote factory that owns this instance */
+
+public:
+
+	RRemoteDir() : m_remoteFactory(nullptr) { }
+
+	int open(const char *a_pattern);
+
+	void close() { }
+
+	int read(TEntryArray *&a_entries, enum TDirSortOrder a_sortOrder = EDirSortNone);
+
+	void setFactory(RRemoteFactory *a_remoteFactory) { m_remoteFactory = a_remoteFactory; }
+};
+
+#endif /* ! REMOTEDIR_H */

--- a/RemoteFactory.h
+++ b/RemoteFactory.h
@@ -1,0 +1,88 @@
+
+#ifndef REMOTEFACTORY_H
+#define REMOTEFACTORY_H
+
+/** @file */
+
+#include "RemoteDir.h"
+#include "RemoteFile.h"
+#include "RemoteFileUtils.h"
+
+/**
+ * A class for management of file system related objects.
+ * This helper class is useful for applications that need to have seamless access to both local and remote
+ * file system objects.  Rather than using the file system related classes directly, applications should
+ * declare an instance of this class, passing in the host name and port of the remote instance of RADRunner
+ * to be used for remote access (if remote access is desired) or no host name (if local access is desired).
+ * This enables the application to switch between remote and local file access dynamically at runtime.
+ */
+
+class RRemoteFactory
+{
+	RDir				m_dir;				/**< Class for local directory scanning */
+	RRemoteDir			m_remoteDir;		/**< Class for remote directory scanning */
+	RFile				m_file;				/**< Class for local file access */
+	RRemoteFile			m_remoteFile;		/**< Class for remote file access */
+	RFileUtils			m_fileUtils;		/**< Class for local file system manipulation */
+	RRemoteFileUtils	m_remoteFileUtils;	/**< Class for remote file system manipulation */
+	std::string			m_serverName;		/**< The host name of the instance of RADRunner to use */
+	unsigned short		m_serverPort;		/**< The port on which RADRunner is listening */
+
+public:
+
+	RDirObject &getDirObject()
+	{
+		if (m_serverName.length() != 0)
+		{
+			m_remoteDir.setFactory(this);
+			return m_remoteDir;
+		}
+		else
+		{
+			return m_dir;
+		}
+	}
+
+	RFileObject &getFileObject()
+	{
+		if (m_serverName.length() != 0)
+		{
+			m_remoteFile.setFactory(this);
+			return m_remoteFile;
+		}
+		else
+		{
+			return m_file;
+		}
+	}
+
+	RFileUtilsObject &getFileUtilsObject()
+	{
+		if (m_serverName.length() != 0)
+		{
+			m_remoteFileUtils.setFactory(this);
+			return m_remoteFileUtils;
+		}
+		else
+		{
+			return m_fileUtils;
+		}
+	}
+
+	bool isRemote()
+	{
+		return m_serverName.length() != 0;
+	}
+
+	std::string &getServer() { return m_serverName; }
+
+	unsigned short &getPort() { return m_serverPort; }
+
+	void setConfig(const std::string &a_serverName, unsigned short a_port)
+	{
+		m_serverName = a_serverName;
+		m_serverPort = a_port;
+	}
+};
+
+#endif /* ! REMOTEFACTORY_H */

--- a/RemoteFile.cpp
+++ b/RemoteFile.cpp
@@ -1,0 +1,335 @@
+
+#include "StdFuncs.h"
+#include "RemoteFactory.h"
+#include "Yggdrasil/Commands.h"
+#include <memory>
+#include <string.h>
+
+#define TRANSFER_SIZE 1024
+
+/**
+ * Sends a file to the remote client.
+ * This command is not required for the remote get implementation, but must be present.
+ *
+ * @date	Sunday 19-Feb-2023 9:15 am, Code HQ Tokyo Tsukuda
+ */
+
+void CGet::execute()
+{
+}
+
+/**
+ * Requests a file from the remote server.
+ * This method does not perform the whole command, but just sends the request and puts the connection
+ * in a state where it can be used for transferring the file.
+ *
+ * @date	Sunday 19-Feb-2023 9:15 am, Code HQ Tokyo Tsukuda
+ */
+
+void CGet::sendRequest()
+{
+	int32_t payloadSize = static_cast<int32_t>(strlen(m_fileName) + 1);
+
+	m_command.m_size = payloadSize;
+	sendCommand();
+	m_socket->write(m_fileName, payloadSize);
+	readResponse();
+}
+
+/**
+ * Receives a file from the remote client.
+ * This command is not required for the remote send implementation, but must be present.
+ *
+ * @date	Saturday 25-Feb-2023 7:57 am, Code HQ Tokyo Tsukuda
+ */
+
+void CSend::execute()
+{
+}
+
+/**
+ * Sends a file to the remote server.
+ * This method does not perform the whole command, but just sends the request and puts the connection
+ * in a state where it can be used for transferring the file.
+ *
+ * @date	Saturday 25-Feb-2023 7:57 am, Code HQ Tokyo Tsukuda
+ */
+
+void CSend::sendRequest()
+{
+	int32_t payloadSize = static_cast<int32_t>(sizeof(SFileInfo) + strlen(m_fileName) + 1);
+
+	m_command.m_size = payloadSize;
+	sendCommand();
+
+	/* Allocate a SFileInfo structure of a size large enough to hold the file's name */
+	SFileInfo *fileInfo = reinterpret_cast<SFileInfo *>(new unsigned char [payloadSize]);
+
+	/* Initialise it with the file's name.  We won't include a timestamp in the packet, but will instead */
+	/* let the server just leave the timestamp at the file's creation time.  It doesn't really make sense */
+	/* to set a timestamp when saving a file from memory */
+	strcpy(fileInfo->m_fileName, m_fileName);
+
+	/* And send the payload */
+	m_socket->write(fileInfo, payloadSize);
+
+	delete [] reinterpret_cast<unsigned char *>(fileInfo);
+}
+
+/**
+ * Creates a new remote file for writing.
+ * This method creates a memory buffer that allows a client to write to the file, as though the file
+ * exists locally.  Operations such as read(), write() and seek() can be performed, as though they were
+ * being performed on a local file, but they affect only the contents of the memory buffer.
+ *
+ * No remote file is actually created at this point.  The file will be created and its contents written
+ * to when @link RFile::close() @endlink is called.
+ *
+ * @date	Thursday 05-Jan-2023 6:50 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	a_fileName		Pointer to the name of the file to be created
+ * @param	a_fileMode		Mode in which to create the file; one of the @link TFileMode @endlink values
+ * @return	KErrNone is always returned, as this method cannot fail
+ */
+
+int RRemoteFile::create(const char *a_fileName, TUint a_fileMode)
+{
+	(void) a_fileMode;
+
+	m_fileName = a_fileName;
+	m_fileOffset = 0;
+
+	return KErrNone;
+}
+
+/**
+ * Creates a new remote file for writing, deleting any that previously exists.
+ * Creates a new file that can subsequently be used for writing operations.  If a file
+ * already exists with the same name then the function will replace it.  This function is
+ * a convenience wrapper around RRemoteFile::create();  see that function for further details.
+ *
+ * @date	Thursday 05-Jan-2023 6:50 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	a_fileName		Pointer to the name of the file to be created
+ * @param	a_fileMode		Mode in which to create the file; one of the @link TFileMode @endlink values
+ * @return	KErrNone is always returned, as this method cannot fail
+ */
+
+int RRemoteFile::replace(const char *a_fileName, TUint a_fileMode)
+{
+	/* The remote server will always delete the file before creating it, so we can just directly call create() */
+	return create(a_fileName, a_fileMode);
+}
+
+/**
+ * Opens a remote existing file for reading and/or writing.
+ * Opens an existing file that can subsequently be used for reading or writing operations, or both.
+ * The file can be opened using the file mode flags EFileRead, EFileWrite, or a logical combination
+ * of them both to elicit the desired behaviour.  If the file mode EFileWrite is specified then the
+ * file will also be writeable.  The a_fileName parameter can optionally include a path to the file.
+ *
+ * @date	Thursday 05-Jan-2023 6:50 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	a_fileName		Pointer to the name of the file to be opened
+ * @param	a_fileMode		Mode in which to open the file; one of the @link TFileMode @endlink values
+ * @return	KErrNone if successful, otherwise one of the system errors
+ */
+
+int RRemoteFile::open(const char *a_fileName, TUint a_fileMode)
+{
+	(void) a_fileMode;
+
+	int retVal = m_socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+
+	if (retVal == KErrNone)
+	{
+		m_socket.write(g_signature, SIGNATURE_SIZE);
+
+		CGet *handler = new CGet(&m_socket, a_fileName);
+		handler->sendRequest();
+
+		if (handler->getResponse()->m_result == KErrNone)
+		{
+			readFromRemote();
+		}
+		else
+		{
+			Utils::Error("RemoteFile: Received invalid response %d", handler->getResponse()->m_result);
+
+			retVal = handler->getResponse()->m_result;
+		}
+
+		delete handler;
+		m_socket.close();
+	}
+	else
+	{
+		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+	}
+
+	return retVal;
+}
+
+/**
+ * Reads a number of bytes from the file.
+ * Reads a number of bytes from the file.  There must be sufficient data in the file to be
+ * able to satisfy the read request, or the function will fail.  It is safe to try and read
+ * 0 bytes.  In this case 0 will be returned.
+ *
+ * @date	Thursday 05-Jan-2023 6:50 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	a_buffer		Pointer to the buffer to read the data into
+ * @param	a_length		Number of bytes in the buffer to be read
+ * @return	Number of bytes read, if successful
+ * @return	KErrGeneral if the read could not be performed
+ */
+
+int RRemoteFile::read(unsigned char *a_buffer, int a_length)
+{
+	int retVal = KErrGeneral;
+
+	if (m_fileOffset + a_length < static_cast<int>(m_fileBuffer.size()))
+	{
+		memcpy(a_buffer, m_fileBuffer.data() + m_fileOffset, a_length);
+		m_fileOffset += a_length;
+		retVal = a_length;
+	}
+	else
+	{
+		memcpy(a_buffer, m_fileBuffer.data() + m_fileOffset, m_fileBuffer.size() - m_fileOffset);
+		retVal = static_cast<int>(m_fileBuffer.size() - m_fileOffset);
+		m_fileOffset += static_cast<int>(m_fileBuffer.size() - m_fileOffset);
+
+		if (retVal == 0)
+		{
+			retVal = KErrEof;
+		}
+	}
+
+	return retVal;
+}
+
+/**
+ * Reads a file from a connected socket.
+ * Read a file from a socket and writes its contents to a buffer in memory.  This method assumes that the
+ * file has been requested and that upon reading the socket, the entire file will be able to be read.
+ *
+ * @pre		A file has been requested from the connected endpoint
+ *
+ * @date	Thursday 05-Jan-2023 7:59 am, MK290 holiday apartment, Naha, Okinawa
+ */
+
+void RRemoteFile::readFromRemote()
+{
+	uint32_t bytesRead = 0, bytesToRead, fileSize, size;
+
+	m_socket.read(&fileSize, sizeof(fileSize));
+	SWAP(&fileSize);
+
+	m_fileBuffer.resize(fileSize);
+
+	do
+	{
+		bytesToRead = ((fileSize - bytesRead) >= TRANSFER_SIZE) ? TRANSFER_SIZE : (fileSize - bytesRead);
+		size = m_socket.read(m_fileBuffer.data() + bytesRead, bytesToRead);
+		bytesRead += size;
+	}
+	while (bytesRead < fileSize);
+
+	m_fileOffset = 0;
+}
+
+/**
+ * Seeks to a specified position in the file.
+ * This is a basic seek function that will seek from the beginning of a file to the position
+ * passed in, that position being a number of bytes from the beginning of the file.
+ *
+ * @date	Thursday 05-Jan-2023 9:12 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	a_bytes			The number of bytes from the start of the file to which to seek
+ * @return	KErrNone if successful
+ * @return	KErrGeneral if the seek could not be performed
+ */
+
+int RRemoteFile::seek(int a_bytes)
+{
+	int retVal = KErrGeneral;
+
+	if (a_bytes >= 0 && a_bytes < static_cast<int>(m_fileBuffer.size()))
+	{
+		retVal = KErrNone;
+		m_fileOffset = a_bytes;
+	}
+
+	return retVal;
+}
+
+/**
+ * Writes a number of bytes to the file.
+ * Writes a number of bytes to the file.  The file must have been opened in a writeable mode,
+ * either by using RRemoteFile::open(EFileWrite), RRemoteFile::replace() or RRemoteFile::create().
+ * In the latter two cases, files are always opened as writeable, regardless of the file mode
+ * passed in.  It is safe to try and write 0 bytes.  In this case 0 will be returned
+ *
+ * @date	Thursday 05-Jan-2023 6:50 am, MK290 holiday apartment, Naha, Okinawa
+ * @param	a_buffer		Pointer to the buffer to be written to the file
+ * @param	a_length		Number of bytes in the buffer to be written
+ * @return	Number of bytes written, if successful
+ * @return	KErrGeneral if the write could not be performed
+ */
+
+int RRemoteFile::write(const unsigned char *a_buffer, int a_length)
+{
+	int retVal = KErrGeneral;
+	size_t endOffset = m_fileOffset + a_length;
+
+	if (endOffset > m_fileBuffer.size())
+	{
+		m_fileBuffer.resize(endOffset);
+	}
+
+	if (endOffset <= m_fileBuffer.size())
+	{
+		m_dirty = true;
+		memcpy(m_fileBuffer.data() + m_fileOffset, a_buffer, a_length);
+		m_fileOffset += a_length;
+		retVal = a_length;
+	}
+
+	return retVal;
+}
+
+/**
+ * Closes a file when access is no longer required.
+ * Closes a file that has been created for reading & writing, or opened for reading.  If changes have
+ * been made to the contents of the memory buffer that represent the remote file, those changes will
+ * be sent to the server for writing to the remote file.
+ *
+ * @date	Thursday 05-Jan-2023 6:51 am, MK290 holiday apartment, Naha, Okinawa
+ */
+
+void RRemoteFile::close()
+{
+	if (m_dirty && m_fileBuffer.size() > 0)
+	{
+		int retVal = m_socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+
+		if (retVal == KErrNone)
+		{
+			m_socket.write(g_signature, SIGNATURE_SIZE);
+
+			CSend *handler = new CSend(&m_socket, m_fileName.c_str());
+			handler->sendRequest();
+
+			int fileSize = static_cast<int>(m_fileBuffer.size());
+			SWAP(&fileSize);
+
+			m_socket.write(&fileSize, sizeof(fileSize));
+			m_socket.write(m_fileBuffer.data(), static_cast<int>(m_fileBuffer.size()));
+
+			delete handler;
+			m_dirty = false;
+		}
+		else
+		{
+			Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+		}
+	}
+
+	m_socket.close();
+}

--- a/RemoteFile.h
+++ b/RemoteFile.h
@@ -1,0 +1,53 @@
+
+#ifndef REMOTEFILE_H
+#define REMOTEFILE_H
+
+/** @file */
+
+#include "File.h"
+#include "StdSocket.h"
+#include <string>
+#include <vector>
+
+class CGet;
+class CSend;
+class RRemoteFactory;
+
+/**
+ * A class for reading from or writing to remote files.
+ * This class enables the remote creation, reading and writing of files in a platform independent manner.
+ */
+
+class RRemoteFile : public RFileObject
+{
+	bool						m_dirty;			/**< True if a write has been performed */
+	int							m_fileOffset;		/**< The current read/write offset into the file */
+	RRemoteFactory				*m_remoteFactory;	/**< Pointer to the remote factory that owns this instance */
+	RSocket						m_socket;			/**< Socket for communicating with remote RADRunner */
+	std::string					m_fileName;			/**< The name of the file on the remote server */
+	std::vector<unsigned char>	m_fileBuffer;		/**< Buffer containing the contents of the file */
+
+	void readFromRemote();
+
+public:
+
+	RRemoteFile() : m_dirty(false), m_fileOffset(0), m_remoteFactory(nullptr) { }
+
+	int create(const char *a_fileName, TUint a_fileMode);
+
+	int replace(const char *a_fileName, TUint a_fileMode);
+
+	int open(const char *a_fileName, TUint a_fileMode);
+
+	int read(unsigned char *a_buffer, int a_length);
+
+	int seek(int a_bytes);
+
+	int write(const unsigned char *a_buffer, int a_length);
+
+	void close();
+
+	void setFactory(RRemoteFactory *a_remoteFactory) { m_remoteFactory = a_remoteFactory; }
+};
+
+#endif /* ! REMOTEFILE_H */

--- a/RemoteFileUtils.cpp
+++ b/RemoteFileUtils.cpp
@@ -1,0 +1,230 @@
+
+#include "StdFuncs.h"
+#include "RemoteFactory.h"
+#include "Yggdrasil/Commands.h"
+#include "StdSocket.h"
+#include <string.h>
+
+/**
+ * Deletes a file.
+ * This command is not required for the remote delete implementation, but must be present.
+ *
+ * @date	Saturday 11-Mar-2023 5:53 am, Code HQ Tokyo Tsukuda
+ */
+
+void CDelete::execute()
+{
+}
+
+/**
+ * Requests the deletion of a file.
+ * Requests the remote server to delete the specified file.
+ *
+ * @date	Saturday 11-Mar-2023 5:53 am, Code HQ Tokyo Tsukuda
+ */
+
+void CDelete::sendRequest()
+{
+	int32_t payloadSize = static_cast<int32_t>(strlen(m_fileName) + 1);
+
+	m_command.m_size = payloadSize;
+	sendCommand();
+	m_socket->write(m_fileName, payloadSize);
+	readResponse();
+}
+
+/**
+ * Determines detailed file information and returns it to the client.
+ * This command is not required for the remote delete implementation, but must be present.
+ *
+ * @date	Friday 24-Feb-2023 6:49 am, Code HQ Tokyo Tsukuda
+ */
+
+void CFileInfo::execute()
+{
+}
+
+/**
+ * Requests detailed file information from the server.
+ * Requests the remote server to query information about the given file, and to return it in the
+ * payload in a @link SFileInfo @endlink structure.
+ *
+ * @date	Friday 24-Feb-2023 6:50 am, Code HQ Tokyo Tsukuda
+ */
+
+void CFileInfo::sendRequest()
+{
+	int32_t payloadSize = static_cast<int32_t>(strlen(m_fileName) + 1);
+
+	m_command.m_size = payloadSize;
+	sendCommand();
+	m_socket->write(m_fileName, payloadSize);
+	readResponse();
+}
+
+/**
+ * Renames a file.
+ * This command is not required for the remote rename implementation, but must be present.
+ *
+ * @date	Saturday 11-Mar-2023 5:53 am, Code HQ Tokyo Tsukuda
+ */
+
+void CRename::execute()
+{
+}
+
+/**
+ * Requests the renaming of a file.
+ * Requests the remote server to rename the specified file to the specified new name.
+ *
+ * @date	Saturday 11-Mar-2023 5:53 am, Code HQ Tokyo Tsukuda
+ */
+
+void CRename::sendRequest()
+{
+	int32_t payloadSize = static_cast<int32_t>(strlen(m_oldName) + 1 + strlen(m_newName) + 1);
+
+	m_command.m_size = payloadSize;
+	sendCommand();
+	m_socket->write(m_oldName, static_cast<int>(strlen(m_oldName) + 1));
+	m_socket->write(m_newName, static_cast<int>(strlen(m_newName) + 1));
+	readResponse();
+}
+
+/**
+ * Deletes a file from the file system.
+ * Requests the remote server to delete the specified file.
+ *
+ * @date	Wednesday 01-Jul-2009 7:54 pm
+ * @param	a_fileName	Name of the file to be deleted
+ * @return	KErrNone if successful, otherwise one of the system errors
+ */
+
+int RRemoteFileUtils::deleteFile(const char *a_fileName)
+{
+	RSocket m_socket;
+
+	int retVal = m_socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+
+	if (retVal == KErrNone)
+	{
+		m_socket.write(g_signature, SIGNATURE_SIZE);
+
+		CDelete *handler = new CDelete(&m_socket, a_fileName);
+		handler->sendRequest();
+
+		if (handler->getResponse()->m_result != KErrNone)
+		{
+			Utils::info("deleteFile: Received invalid response %d", handler->getResponse()->m_result);
+
+			retVal = handler->getResponse()->m_result;
+		}
+
+		delete handler;
+		m_socket.close();
+	}
+	else
+	{
+		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+	}
+
+	return retVal;
+}
+
+/**
+ * Obtains information about a given remote file or directory.
+ * Wrapper method that enables remote operation of the @link Utils::GetFileInfo() @endlink method.
+ * See @link Utils::GetFileInfo() @endlink for more detailed information.
+ *
+ * @pre		Pointer to filename passed in must not be NULL
+ * @pre		Pointer to TEntry structure passed in must not be NULL
+ *
+ * @date	Friday 24-Feb-2023 6:47 am, Code HQ Tokyo Tsukuda
+ * @param	a_fileName	Pointer to the name of the file for which to obtain information
+ * @param	a_entry		Pointer to the TEntry structure into which to place the information
+ * @return	KErrNone if successful, otherwise one of the system errors
+ */
+
+int RRemoteFileUtils::getFileInfo(const char *a_fileName, TEntry *a_entry)
+{
+	ASSERTM((a_entry != nullptr), "RRemoteFileUtils::getFileInfo() => Pointer to filename passed in must not be NULL");
+	ASSERTM((a_entry != nullptr), "RRemoteFileUtils::getFileInfo() => TEntry structure passed in must not be NULL");
+
+	RSocket socket;
+	int retVal = socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+
+	if (retVal == KErrNone)
+	{
+		socket.write(g_signature, SIGNATURE_SIZE);
+
+		CFileInfo* handler = new CFileInfo(&socket, a_fileName);
+		handler->sendRequest();
+
+		if (handler->getResponse()->m_result == KErrNone)
+		{
+			SFileInfo *fileInfo = reinterpret_cast<SFileInfo *>(handler->getResponsePayload());
+			SWAP64(&fileInfo->m_microseconds);
+			SWAP(&fileInfo->m_size);
+
+			TDateTime dateTime(fileInfo->m_microseconds);
+
+			a_entry->Set(fileInfo->m_isDir, fileInfo->m_isLink, fileInfo->m_size, 0, dateTime);
+		}
+		else
+		{
+			Utils::Error("RemoteFileInfo: Received invalid response %d", handler->getResponse()->m_result);
+
+			retVal = handler->getResponse()->m_result;
+		}
+
+		delete handler;
+		socket.close();
+	}
+	else
+	{
+		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+	}
+
+	return retVal;
+}
+
+/**
+  * Renames a file.
+  * Requests the remote server to rename the specified file to the specified new name.
+  *
+  * @date	Wednesday 08-Mar-2023 7:02 am, Code HQ Tokyo Tsukuda
+  * @param	a_oldFullName	The current name of the file to be renamed
+  * @param	a_newFullName	The new name to which to rename the file
+  * @return	KErrNone if successful, else KErrGeneral
+  */
+
+int RRemoteFileUtils::renameFile(const char *a_oldFullName, const char *a_newFullName)
+{
+	RSocket socket;
+
+	int retVal = socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+
+	if (retVal == KErrNone)
+	{
+		socket.write(g_signature, SIGNATURE_SIZE);
+
+		CRename *handler = new CRename(&socket, a_oldFullName, a_newFullName);
+		handler->sendRequest();
+
+		if (handler->getResponse()->m_result != KErrNone)
+		{
+			Utils::info("renameFile: Received invalid response %d", handler->getResponse()->m_result);
+
+			retVal = handler->getResponse()->m_result;
+		}
+
+		delete handler;
+		socket.close();
+	}
+	else
+	{
+		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+	}
+
+	return retVal;
+}

--- a/RemoteFileUtils.h
+++ b/RemoteFileUtils.h
@@ -1,0 +1,33 @@
+
+#ifndef REMOTEFILEUTILS_H
+#define REMOTEFILEUTILS_H
+
+/** @file */
+
+#include "FileUtils.h"
+
+class RRemoteFactory;
+
+/**
+ * A class for performing miscellaneous remote file operations.
+ * Instances of this class can be used to delete, rename and query files and directories on the remote file system.
+ */
+
+class RRemoteFileUtils : public RFileUtilsObject
+{
+	RRemoteFactory	*m_remoteFactory;	/**< Pointer to the remote factory that owns this instance */
+
+public:
+
+	RRemoteFileUtils() : m_remoteFactory(nullptr) { }
+
+	int deleteFile(const char *a_fileName);
+
+	int getFileInfo(const char *a_fileName, TEntry *a_entry);
+
+	int renameFile(const char *a_oldFullName, const char *a_newFullName);
+
+	void setFactory(RRemoteFactory *a_remoteFactory) { m_remoteFactory = a_remoteFactory; }
+};
+
+#endif /* ! REMOTEFILEUTILS_H */

--- a/StdFuncs.pro
+++ b/StdFuncs.pro
@@ -26,6 +26,7 @@ MOC_DIR = $$OBJECTS_DIR
 DEFINES -= UNICODE
 
 SOURCES += Args.cpp Dir.cpp File.cpp FileUtils.cpp Lex.cpp MungWall.cpp \
+    RemoteDir.cpp RemoteFile.cpp RemoteFileUtils.cpp Yggdrasil/Handler.cpp \
 	StdApplication.cpp StdCharConverter.cpp StdClipboard.cpp StdConfigFile.cpp StdCRC.cpp StdDialog.cpp StdFileRequester.cpp \
 	StdFont.cpp StdGadgets.cpp StdGadgetLayout.cpp StdGadgetSlider.cpp StdGadgetStatusBar.cpp StdGadgetTree.cpp \
 	StdImage.cpp StdPool.cpp StdRendezvous.cpp StdSocket.cpp StdStringList.cpp StdTextFile.cpp StdTime.cpp \

--- a/StdFuncs.vcxproj
+++ b/StdFuncs.vcxproj
@@ -208,6 +208,9 @@
     <ClCompile Include="File.cpp" />
     <ClCompile Include="Lex.cpp" />
     <ClCompile Include="MungWall.cpp" />
+    <ClCompile Include="RemoteDir.cpp" />
+    <ClCompile Include="RemoteFile.cpp" />
+    <ClCompile Include="RemoteFileUtils.cpp" />
     <ClCompile Include="StdApplication.cpp" />
     <ClCompile Include="StdCharConverter.cpp" />
     <ClCompile Include="StdClipboard.cpp" />
@@ -241,6 +244,10 @@
     <ClInclude Include="File.h" />
     <ClInclude Include="Lex.h" />
     <ClInclude Include="MungWall.h" />
+    <ClInclude Include="RemoteDir.h" />
+    <ClInclude Include="RemoteFactory.h" />
+    <ClInclude Include="RemoteFile.h" />
+    <ClInclude Include="RemoteFileUtils.h" />
     <ClInclude Include="StdApplication.h" />
     <ClInclude Include="StdCharConverter.h" />
     <ClInclude Include="StdClipboard.h" />

--- a/makefile
+++ b/makefile
@@ -37,6 +37,7 @@ LIBRARY = $(OBJ)/libStdFuncs.a
 
 ifdef PREFIX
 	OBJECTS = $(OBJ)/AmiMenus.o $(OBJ)/Args.o $(OBJ)/Dir.o $(OBJ)/File.o $(OBJ)/FileUtils.o $(OBJ)/Lex.o $(OBJ)/MungWall.o \
+		$(OBJ)/RemoteDir.o $(OBJ)/RemoteFile.o $(OBJ)/RemoteFileUtils.o \
 		$(OBJ)/StdApplication.o $(OBJ)/StdCharConverter.o $(OBJ)/StdClipboard.o $(OBJ)/StdConfigFile.o $(OBJ)/StdCRC.o $(OBJ)/StdDialog.o \
 		$(OBJ)/StdFileRequester.o $(OBJ)/StdFont.o $(OBJ)/StdGadgets.o $(OBJ)/StdGadgetLayout.o $(OBJ)/StdGadgetSlider.o \
 		$(OBJ)/StdGadgetStatusBar.o $(OBJ)/StdGadgetTree.o $(OBJ)/StdImage.o $(OBJ)/StdPool.o $(OBJ)/StdRendezvous.o $(OBJ)/StdSocket.o \
@@ -53,6 +54,7 @@ ifdef PREFIX
 	endif
 else
 	OBJECTS = $(OBJ)/Args.o $(OBJ)/StdCharConverter.o $(OBJ)/Dir.o $(OBJ)/File.o $(OBJ)/FileUtils.o $(OBJ)/Lex.o $(OBJ)/MungWall.o \
+		$(OBJ)/RemoteDir.o $(OBJ)/RemoteFile.o $(OBJ)/RemoteFileUtils.o \
 		$(OBJ)/StdConfigFile.o $(OBJ)/StdCRC.o $(OBJ)/StdPool.o $(OBJ)/StdRendezvous.o $(OBJ)/StdSocket.o $(OBJ)/StdStringList.o \
 		$(OBJ)/StdTextFile.o $(OBJ)/StdTime.o $(OBJ)/StdWildcard.o $(OBJ)/Test.o $(OBJ)/Utils.o
 endif


### PR DESCRIPTION
This allows derivatives of the RDir and RFile classes, and the new RFileInfo class, to be used for accessing files remotely using RADRunner as a server.