### PR TITLE
Add separate RSocket::accept() method

### DIFF
--- a/StdSocket.cpp
+++ b/StdSocket.cpp
@@ -44,7 +44,7 @@ RSocket::Error::~Error() noexcept
 
 RSocket::RSocket()
 {
-	m_iServerSocket = m_iSocket = INVALID_SOCKET;
+	m_serverSocket = m_socket = INVALID_SOCKET;
 }
 
 /**
@@ -55,51 +55,50 @@ RSocket::RSocket()
  * opened in a state suitable for listening.
  *
  * @date	Saturday 11-Feb-2017 4:37 pm, Code HQ Habersaathstrasse
- * @param	a_pccHost		The name of the host, an IP address or NULL
- * @param	a_usPort		The port to which to connect
+ * @param	a_host			The name of the host, an IP address or NULL
+ * @param	a_port			The port to which to connect
  * @return	KErrNone if successful
  * @return	KErrGeneral if the socket could not be opened
  * @return	KErrHostNotFound if the host could not be resolved
  */
 
-int RSocket::open(const char *a_pccHost, unsigned short a_usPort)
+int RSocket::open(const char *a_host, unsigned short a_port)
 {
-	int RetVal;
-	struct hostent *HostEnt;
-	struct in_addr *InAddr;
-	struct sockaddr_in SockAddr;
+	int retVal = KErrGeneral;
 
-	RetVal = KErrGeneral;
+	struct hostent *hostEnt;
+	struct in_addr *inAddr;
+	struct sockaddr_in sockAddr;
 
 #ifdef WIN32
 
-	WSAData WSAData;
+	WSAData wsaData;
 
-	if (WSAStartup(MAKEWORD(2, 2), &WSAData) == 0)
+	if (WSAStartup(MAKEWORD(2, 2), &wsaData) == 0)
 
 #endif /* WIN32 */
 
 	{
-		if ((m_iSocket = socket(AF_INET, SOCK_STREAM, 0)) != INVALID_SOCKET)
+		if ((m_socket = socket(AF_INET, SOCK_STREAM, 0)) != INVALID_SOCKET)
 		{
-			if (a_pccHost)
+			if (a_host)
 			{
-				if ((HostEnt = gethostbyname(a_pccHost)) != nullptr)
+				if ((hostEnt = gethostbyname(a_host)) != nullptr)
 				{
-					InAddr = (struct in_addr *) HostEnt->h_addr_list[0];
+					inAddr = (struct in_addr *) hostEnt->h_addr_list[0];
 
-					SockAddr.sin_family = HostEnt->h_addrtype;
-					SockAddr.sin_port = htons(a_usPort);
-					SockAddr.sin_addr = *InAddr;
+					sockAddr.sin_family = hostEnt->h_addrtype;
+					sockAddr.sin_port = htons(a_port);
+					sockAddr.sin_addr = *inAddr;
 
-					if (connect(m_iSocket, (struct sockaddr *) &SockAddr, sizeof(SockAddr)) >= 0)
+					if (connect(m_socket, (struct sockaddr *) &sockAddr, sizeof(sockAddr)) >= 0)
 					{
-						RetVal = KErrNone;
+						retVal = KErrNone;
 					}
 				}
 				else
 				{
-					RetVal = KErrHostNotFound;
+					retVal = KErrHostNotFound;
 				}
 			}
 			else
@@ -108,15 +107,15 @@ int RSocket::open(const char *a_pccHost, unsigned short a_usPort)
 				/* immediately reopened for the next client connection */
 				struct linger Linger = { 1, 0 };
 
-				if (setsockopt(m_iSocket, SOL_SOCKET, SO_LINGER, (const char *) &Linger, sizeof(Linger)) == 0)
+				if (setsockopt(m_socket, SOL_SOCKET, SO_LINGER, (const char *) &Linger, sizeof(Linger)) == 0)
 				{
-					RetVal = KErrNone;
+					retVal = KErrNone;
 				}
 			}
 		}
 	}
 
-	return(RetVal);
+	return retVal;
 }
 
 /**
@@ -128,16 +127,16 @@ int RSocket::open(const char *a_pccHost, unsigned short a_usPort)
 
 void RSocket::close()
 {
-	if (m_iSocket != INVALID_SOCKET)
+	if (m_socket != INVALID_SOCKET)
 	{
-		closesocket(m_iSocket);
-		m_iSocket = INVALID_SOCKET;
+		closesocket(m_socket);
+		m_socket = INVALID_SOCKET;
 	}
 
-	if (m_iServerSocket != INVALID_SOCKET)
+	if (m_serverSocket != INVALID_SOCKET)
 	{
-		closesocket(m_iServerSocket);
-		m_iServerSocket = INVALID_SOCKET;
+		closesocket(m_serverSocket);
+		m_serverSocket = INVALID_SOCKET;
 	}
 
 #ifdef WIN32
@@ -157,74 +156,73 @@ void RSocket::close()
  * @pre		The socket has been opened with open()
  *
  * @date	Sunday 12-Feb-2017 7:53 am, Code HQ Habersaathstrasse
- * @param	a_usPort		The port on which to listen for connections
- * @return	KErrNone if successful, else KErrGeneral if host connection failed
+ * @param	a_port			The port on which to listen for connections
+ * @return	KErrNone if successful, otherwise KErrGeneral
  */
 
-int RSocket::listen(unsigned short a_usPort)
+int RSocket::listen(unsigned short a_port)
 {
-	int RetVal;
-	socklen_t ClientSize;
-	SOCKET Socket;
-	struct sockaddr_in Server, Client;
+	int retVal = KErrGeneral;
 
-	RetVal = KErrGeneral;
+	socklen_t clientSize;
+	SOCKET socket;
+	struct sockaddr_in server, client;
 
-	Server.sin_family = AF_INET;
-	Server.sin_port = htons(a_usPort);
-	Server.sin_addr.s_addr = INADDR_ANY;
+	server.sin_family = AF_INET;
+	server.sin_port = htons(a_port);
+	server.sin_addr.s_addr = INADDR_ANY;
 
-	if (bind(m_iSocket, (struct sockaddr *) &Server, sizeof(Server)) != SOCKET_ERROR)
+	if (bind(m_socket, (struct sockaddr *) &server, sizeof(server)) != SOCKET_ERROR)
 	{
-		if (::listen(m_iSocket, 1) == 0)
+		if (::listen(m_socket, 1) == 0)
 		{
-			ClientSize = sizeof(Client);
-			Socket = accept(m_iSocket, (struct sockaddr *) &Client, &ClientSize);
+			clientSize = sizeof(client);
+			socket = accept(m_socket, (struct sockaddr *) &client, &clientSize);
 
-			if (Socket != INVALID_SOCKET)
+			if (socket != INVALID_SOCKET)
 			{
-				RetVal = KErrNone;
+				retVal = KErrNone;
 
-				m_iServerSocket = m_iSocket;
-				m_iSocket = Socket;
+				m_serverSocket = m_socket;
+				m_socket = socket;
 			}
 		}
 	}
 
-	return(RetVal);
+	return retVal;
 }
 
 /**
  * Reads data from the socket.
  * Reads the number of bytes requested from the socket.  This method can operated in a "read all" mode and
  * a "read waiting" mode, as specified by the a_bReadAll parameter.  If this is specified as true then the
- * entire number of bytes specified by a_iSize will be read, even if this involves blocking.  If this is
+ * entire number of bytes specified by a_size will be read, even if this involves blocking.  If this is
  * false then only the number of bytes waiting on the socket will be read.
  *
  * @pre		The socket has been opened with open()
  *
  * @date	Saturday 11-Feb-2017 5:59 pm, Code HQ Habersaathstrasse
- * @param	a_pvBuffer		Pointer to the buffer into which to read the data
- * @param	a_iSize			The number of bytes to be read
- * @param	a_bReadAll		true to read entire number of bytes specified
+ * @param	a_buffer		Pointer to the buffer into which to read the data
+ * @param	a_size			The number of bytes to be read
+ * @param	a_readAll		true to read entire number of bytes specified
  * @throw	Error			If the socket could not be read from or was closed
  * @return	The number of bytes received
  */
 
-int RSocket::read(void *a_pvBuffer, int a_iSize, bool a_bReadAll)
+int RSocket::read(void *a_buffer, int a_size, bool a_readAll)
 {
-	char *buffer = (char *) a_pvBuffer;
+	char *buffer = (char *) a_buffer;
 	int bytesToRead, retVal = 0, size;
 
-	if (a_bReadAll)
+	if (a_readAll)
 	{
 		/* Loop around, trying to read however many bytes are left to be read, starting with the total number */
 		/* of bytes and gradually reducing the size until all have been read */
 		do
 		{
-			bytesToRead = (a_iSize - retVal);
+			bytesToRead = (a_size - retVal);
 
-			if ((size = recv(m_iSocket, (buffer + retVal), bytesToRead, 0)) > 0)
+			if ((size = recv(m_socket, (buffer + retVal), bytesToRead, 0)) > 0)
 			{
 				retVal += size;
 			}
@@ -234,11 +232,11 @@ int RSocket::read(void *a_pvBuffer, int a_iSize, bool a_bReadAll)
 				break;
 			}
 		}
-		while (retVal < a_iSize);
+		while (retVal < a_size);
 	}
 	else
 	{
-		retVal = recv(m_iSocket, buffer, a_iSize, 0);
+		retVal = recv(m_socket, buffer, a_size, 0);
 	}
 
 	if (retVal < 0)
@@ -255,30 +253,30 @@ int RSocket::read(void *a_pvBuffer, int a_iSize, bool a_bReadAll)
 
 /**
  * Writes data to the socket.
- * Writes the number of bytes requested to the socket.  The entire number of bytes specified by a_iSize
+ * Writes the number of bytes requested to the socket.  The entire number of bytes specified by a_size
  * will be written, even if this involves blocking.
  *
  * @pre		The socket has been opened with open()
  *
  * @date	Saturday 11-Feb-2017 5:55 pm, Code HQ Habersaathstrasse
- * @param	a_pcvBuffer		Pointer to the buffer from which to write the data
- * @param	a_iSize			The number of bytes to be written
+ * @param	a_buffer		Pointer to the buffer from which to write the data
+ * @param	a_size			The number of bytes to be written
  * @throw	Error			If the socket could not be written to or was closed
  * @return	The number of bytes sent
  */
 
-int RSocket::write(const void *a_pcvBuffer, int a_iSize)
+int RSocket::write(const void *a_buffer, int a_size)
 {
-	const char *buffer = (const char *) a_pcvBuffer;
+	const char *buffer = (const char *) a_buffer;
 	int bytesToWrite, retVal = 0, size;
 
 	/* Loop around, trying to write however many bytes are left to be written, starting with the total number */
 	/* of bytes and gradually reducing the size until all have been written */
 	do
 	{
-		bytesToWrite = (a_iSize - retVal);
+		bytesToWrite = (a_size - retVal);
 
-		if ((size = send(m_iSocket, (buffer + retVal), bytesToWrite, 0)) > 0)
+		if ((size = send(m_socket, (buffer + retVal), bytesToWrite, 0)) > 0)
 		{
 			retVal += size;
 		}
@@ -288,7 +286,7 @@ int RSocket::write(const void *a_pcvBuffer, int a_iSize)
 			break;
 		}
 	}
-	while (retVal < a_iSize);
+	while (retVal < a_size);
 
 	if (retVal <= 0)
 	{
@@ -308,11 +306,11 @@ int RSocket::write(const void *a_pcvBuffer, int a_iSize)
  * terminator itself.
  *
  * @date	Sunday 10-Jan-2021 7:30 am, Code HQ Bergmannstrasse
- * @param	a_pccBuffer		A pointer to the NULL terminated string to be written
+ * @param	a_buffer		A pointer to the NULL terminated string to be written
  * @return	The number of bytes written to the socket
  */
 
-int RSocket::write(const char *a_pccBuffer)
+int RSocket::write(const char *a_buffer)
 {
-	return(write((const void *) a_pccBuffer, (int) (strlen(a_pccBuffer) + 1)));
+	return write((const void *) a_buffer, (int) (strlen(a_buffer) + 1));
 }

--- a/StdSocket.h
+++ b/StdSocket.h
@@ -60,6 +60,8 @@ public:
 
 	void close();
 
+	int accept();
+
 	int listen(unsigned short a_port);
 
 	int read(void* a_buffer, int a_size, bool a_readAll = true);

--- a/StdSocket.h
+++ b/StdSocket.h
@@ -41,11 +41,11 @@ public:
 
 private:
 
-	SOCKET	m_iServerSocket;	/**< The socket on which to listen for connections */
+	SOCKET	m_serverSocket;		/**< The socket on which to listen for connections */
 
 public:
 
-	SOCKET	m_iSocket;			/**< The socket with which data to transfer data */
+	SOCKET	m_socket;			/**< The socket with which data to transfer data */
 
 public:
 
@@ -56,17 +56,17 @@ public:
 		close();
 	}
 
-	int open(const char *a_pccAddress, unsigned short a_usPort);
+	int open(const char* a_host, unsigned short a_port);
 
 	void close();
 
-	int listen(unsigned short a_usPort);
+	int listen(unsigned short a_port);
 
-	int read(void *a_pvBuffer, int a_iSize, bool a_bReadAll = true);
+	int read(void* a_buffer, int a_size, bool a_readAll = true);
 
-	int write(const void *a_pcvBuffer, int a_iSize);
+	int write(const void* a_buffer, int a_size);
 
-	int write(const char *a_pccBuffer);
+	int write(const char* a_buffer);
 };
 
 #endif /* ! STDSOCKET_H */


### PR DESCRIPTION
Until now, the calls to the BSD listen() and accept() functions were
done inside RSocket::listen(), to make things simpler for the caller,
but with the reimplementation of the Yyggdrasil protocol for Brunel
working a bit differently, it was necessary to split the two function
calls into two separate methods.