### PR TITLE
Bug Fix: EFileWrite was not being saved

### DIFF
--- a/File.cpp
+++ b/File.cpp
@@ -72,7 +72,7 @@ int RFile::create(const char *a_fileName, TUint a_fileMode)
 		{
 			RetVal = KErrNone;
 
-			a_fileMode = EFileWrite;
+			m_fileMode = EFileWrite;
 
 			/* And change the shared lock to an exclusive lock, if exclusive mode has been requested */
 

--- a/StdFuncs.vcxproj
+++ b/StdFuncs.vcxproj
@@ -262,6 +262,7 @@
     <ClInclude Include="StdList.h" />
     <ClInclude Include="StdPool.h" />
     <ClInclude Include="StdRendezvous.h" />
+    <ClInclude Include="StdSocket.h" />
     <ClInclude Include="StdStringList.h" />
     <ClInclude Include="StdTextFile.h" />
     <ClInclude Include="StdTime.h" />

--- a/StdSocket.cpp
+++ b/StdSocket.cpp
@@ -167,7 +167,7 @@ int RSocket::accept()
 
 	ASSERTM((m_serverSocket != INVALID_SOCKET), "RSocket::accept() => Socket is not in listening state")
 
-		clientSize = sizeof(client);
+	clientSize = sizeof(client);
 	m_socket = ::accept(m_serverSocket, (struct sockaddr*) &client, &clientSize);
 
 	if (m_socket != INVALID_SOCKET)


### PR DESCRIPTION
During modernisation renaming, an assignment to m_uiFileMode was changed to a_fileMode instead of m_fileMode, causing file sending to fail on RADRunner.  To make things worse, writes were not being checked when saving the file, so a zero length file was written and no error was displayed.

This is proof that you shouldn't touch working code!