### PR TITLE
Bug Fix: CDir was not working properly on Amiga OS

### DIFF
--- a/RemoteDir.cpp
+++ b/RemoteDir.cpp
@@ -56,7 +56,7 @@ int RRemoteDir::open(const char *a_pattern)
 	{
 		socket.write(g_signature, SIGNATURE_SIZE);
 
-		CDir *handler = new CDir(&socket, ".");
+		CDir *handler = new CDir(&socket, a_pattern);
 		handler->sendRequest();
 
 		if (handler->getResponse()->m_result == KErrNone)
@@ -78,7 +78,7 @@ int RRemoteDir::open(const char *a_pattern)
 			{
 				name = reinterpret_cast<const char *>(payload);
 				payload += strlen(name) + 1;
-				STREAM_INT(size, payload);
+				READ_INT(size, payload);
 				payload += sizeof(size);
 
 				if ((Entry = m_entries.Append(name)) != NULL)

--- a/Yggdrasil/Commands.h
+++ b/Yggdrasil/Commands.h
@@ -25,11 +25,17 @@
 /* The size of the buffer used for capturing stdout */
 #define STDOUT_BUFFER_SIZE 1024
 
-#define STREAM_INT(Dest, Source) \
+#define READ_INT(Dest, Source) \
 	Dest = (*Source << 24) | \
 	(*(Source + 1) << 16) | \
 	(*(Source + 2) << 8) | \
 	*(Source + 3)
+
+#define WRITE_INT(Dest, Value) \
+	*Dest = (Value >> 24) & 0xff; \
+	*(Dest + 1) = (Value >> 16) & 0xff; \
+	*(Dest + 2) = (Value >> 8) & 0xff; \
+	*(Dest + 3) = Value & 0xff
 
 /**
  * The commands supported by the program.


### PR DESCRIPTION
Removed a hard-coded "." path and updated integer reading and writing macros to function identially on Amiga OS and other operating systems.