### PR TITLE
Change errors to info prints

### DIFF
--- a/RemoteDir.cpp
+++ b/RemoteDir.cpp
@@ -91,7 +91,7 @@ int RRemoteDir::open(const char *a_pattern)
 		}
 		else
 		{
-			Utils::Error("RemoteDir: Received invalid response %d", handler->getResponse()->m_result);
+			Utils::info("RRemoteDir::open() => Received invalid response %d", handler->getResponse()->m_result);
 
 			retVal = handler->getResponse()->m_result;
 		}
@@ -101,7 +101,7 @@ int RRemoteDir::open(const char *a_pattern)
 	}
 	else
 	{
-		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+		Utils::info("RRemoteDir::open() => Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
 	}
 
 	return retVal;

--- a/RemoteFile.cpp
+++ b/RemoteFile.cpp
@@ -151,7 +151,7 @@ int RRemoteFile::open(const char *a_fileName, TUint a_fileMode)
 		}
 		else
 		{
-			Utils::Error("RemoteFile: Received invalid response %d", handler->getResponse()->m_result);
+			Utils::info("RRemoteFile::open() => Received invalid response %d", handler->getResponse()->m_result);
 
 			retVal = handler->getResponse()->m_result;
 		}
@@ -161,7 +161,7 @@ int RRemoteFile::open(const char *a_fileName, TUint a_fileMode)
 	}
 	else
 	{
-		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+		Utils::info("RRemoteFile::open() => Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
 	}
 
 	return retVal;
@@ -327,7 +327,7 @@ void RRemoteFile::close()
 		}
 		else
 		{
-			Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+			Utils::info("RRemoteFile::close() => Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
 		}
 	}
 

--- a/RemoteFileUtils.cpp
+++ b/RemoteFileUtils.cpp
@@ -115,7 +115,7 @@ int RRemoteFileUtils::deleteFile(const char *a_fileName)
 
 		if (handler->getResponse()->m_result != KErrNone)
 		{
-			Utils::info("deleteFile: Received invalid response %d", handler->getResponse()->m_result);
+			Utils::info("RRemoteFileUtils::deleteFile() => Received invalid response %d", handler->getResponse()->m_result);
 
 			retVal = handler->getResponse()->m_result;
 		}
@@ -125,7 +125,7 @@ int RRemoteFileUtils::deleteFile(const char *a_fileName)
 	}
 	else
 	{
-		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+		Utils::info("RRemoteFileUtils::deleteFile() => Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
 	}
 
 	return retVal;
@@ -172,7 +172,7 @@ int RRemoteFileUtils::getFileInfo(const char *a_fileName, TEntry *a_entry)
 		}
 		else
 		{
-			Utils::Error("RemoteFileInfo: Received invalid response %d", handler->getResponse()->m_result);
+			Utils::info("RRemoteFileUtils::getFileInfo() => Received invalid response %d", handler->getResponse()->m_result);
 
 			retVal = handler->getResponse()->m_result;
 		}
@@ -182,7 +182,7 @@ int RRemoteFileUtils::getFileInfo(const char *a_fileName, TEntry *a_entry)
 	}
 	else
 	{
-		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+		Utils::info("RRemoteFileUtils::getFileInfo() => Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
 	}
 
 	return retVal;
@@ -213,7 +213,7 @@ int RRemoteFileUtils::renameFile(const char *a_oldFullName, const char *a_newFul
 
 		if (handler->getResponse()->m_result != KErrNone)
 		{
-			Utils::info("renameFile: Received invalid response %d", handler->getResponse()->m_result);
+			Utils::info("RRemoteFileUtils::renameFile() => Received invalid response %d", handler->getResponse()->m_result);
 
 			retVal = handler->getResponse()->m_result;
 		}
@@ -223,7 +223,7 @@ int RRemoteFileUtils::renameFile(const char *a_oldFullName, const char *a_newFul
 	}
 	else
 	{
-		Utils::Error("Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+		Utils::info("RRemoteFileUtils::renameFile() => Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
 	}
 
 	return retVal;


### PR DESCRIPTION
The StdFuncs support library should not be displaying errors if something goes wrong, but should only display info messages, and then only in debug mode.