### PR TITLE
Add CStdGadget::SetFocus()

### DIFF
--- a/StdGadgetLayout.cpp
+++ b/StdGadgetLayout.cpp
@@ -905,3 +905,24 @@ bool CStdGadgetLayout::SendUpdate(void *a_pvGadget, ULONG a_ulData)
 
 	return(RetVal);
 }
+
+/**
+ * Set the input focus to this gadget.
+ * Set the focus to this layout gadget, so that all keyboard input flows directly to the gadget.
+ *
+ * @date	Saturday 08-Apr-2023 1:38 pm, Excelsior Caffé Akihabara
+ */
+
+void CStdGadgetLayout::SetFocus()
+{
+
+#ifdef QT_GUI_LIB
+
+	if (m_poLayout)
+	{
+		m_poLayout->parentWidget()->setFocus();
+	}
+
+#endif /* QT_GUI_LIB */
+
+}

--- a/StdGadgetTree.cpp
+++ b/StdGadgetTree.cpp
@@ -1,10 +1,13 @@
 
 #include "StdFuncs.h"
 #include "StdGadgets.h"
-#include "StdReaction.h"
 #include "StdWindow.h"
 
-#ifdef QT_GUI_LIB
+#ifdef __amigaos__
+
+#include "StdReaction.h"
+
+#elif defined(QT_GUI_LIB)
 
 #include "Qt/QtGadgetTree.h"
 #include "Qt/QtWindow.h"

--- a/StdGadgets.h
+++ b/StdGadgets.h
@@ -110,6 +110,8 @@ public:
 		return(m_poParentWindow);
 	}
 
+	virtual void SetFocus() { };
+
 	virtual void SetVisible(bool a_bVisible);
 
 	bool Visible()
@@ -237,6 +239,8 @@ public:
 	}
 
 	/* From CStdGadget */
+
+	virtual void SetFocus();
 
 	virtual TInt X();
 


### PR DESCRIPTION
Adds the virtual method SetFocus() to the CStdGadget class and adds a concrete implementation for the CStdGadgetLayout class, to ensure the editor layout is activated on Qt builds.