### PR TITLE
Bug Fix: Calculate window height correctly on Win32

### DIFF
--- a/Utils.cpp
+++ b/Utils.cpp
@@ -1621,7 +1621,7 @@ int Utils::GetShellHeight()
 			/* And determine the height of the console for the caller, converting the zero based line */
 			/* number of the bottom most line into a count of lines */
 
-			RetVal = (ScreenBufferInfo.srWindow.Bottom + 1);
+			RetVal = (ScreenBufferInfo.srWindow.Bottom - ScreenBufferInfo.srWindow.Top + 1);
 		}
 		else
 		{


### PR DESCRIPTION
The window height calculations were not taking into account the offset of the top of the window, so were sometimes returning very large numbers that were incorrect.