### PR TITLE
Add a return value to RFileObject::close()

### DIFF
--- a/Dir.cpp
+++ b/Dir.cpp
@@ -136,7 +136,7 @@ TEntry::TEntry(const TDateTime &a_roDateTime)
 /**
  * Clears a file's archive attribute.
  * Clears a file's archive attribute, thus indicating that the file has been archived and is no
- * longer changed on disk.  The next time the file is edited by a program, the archive attribute
+ * longer changed on disc.  The next time the file is edited by a program, the archive attribute
  * will again be set, indicating to backup software that the file needs to be backed up.
  * This function currently only performs an action on Windows.
  *

--- a/File.cpp
+++ b/File.cpp
@@ -546,9 +546,10 @@ int RFile::write(const unsigned char *a_buffer, int a_length)
  * Closes a file that has been created for reading & writing, or opened for reading.
  *
  * @date	Friday 02-Jan-2009 8:58 pm
+ * @return	KErrNone is always returned, as this method cannot fail
  */
 
-void RFile::close()
+int RFile::close()
 {
 
 #ifdef __amigaos__
@@ -577,4 +578,5 @@ void RFile::close()
 
 #endif /* ! __unix__ */
 
+	return KErrNone;
 }

--- a/File.h
+++ b/File.h
@@ -40,7 +40,7 @@ public:
 
 	virtual int write(const unsigned char *a_buffer, int a_length) = 0;
 
-	virtual void close() = 0;
+	virtual int close() = 0;
 };
 
 /**
@@ -83,7 +83,7 @@ public:
 
 	int write(const unsigned char *a_buffer, int a_length);
 
-	void close();
+	int close();
 };
 
 #endif /* ! FILE_H */

--- a/RemoteFile.cpp
+++ b/RemoteFile.cpp
@@ -301,13 +301,16 @@ int RRemoteFile::write(const unsigned char *a_buffer, int a_length)
  * be sent to the server for writing to the remote file.
  *
  * @date	Thursday 05-Jan-2023 6:51 am, MK290 holiday apartment, Naha, Okinawa
+ * @return	KErrNone if successful, otherwise one of the errors from RSocket::open()
  */
 
-void RRemoteFile::close()
+int RRemoteFile::close()
 {
+	int retVal = KErrNone;
+
 	if (m_dirty && m_fileBuffer.size() > 0)
 	{
-		int retVal = m_socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+		retVal = m_socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
 
 		if (retVal == KErrNone)
 		{
@@ -332,4 +335,6 @@ void RRemoteFile::close()
 	}
 
 	m_socket.close();
+
+	return retVal;
 }

--- a/RemoteFile.h
+++ b/RemoteFile.h
@@ -45,7 +45,7 @@ public:
 
 	int write(const unsigned char *a_buffer, int a_length);
 
-	void close();
+	int close();
 
 	void setFactory(RRemoteFactory *a_remoteFactory) { m_remoteFactory = a_remoteFactory; }
 };


### PR DESCRIPTION
Now that remote file systems are supported, the chances of close() failing is much higher, so we now return value that can be checked by clients.  This is most likely to fail in the RRemoteFile implementation of the class, if the remote instance of RADRunner goes offline during use.