### PR TITLE
Use different names for libraries

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Archive Libraries
         uses: actions/upload-artifact@v3
         with:
-          name: Libraries
+          name: Linux-Libraries
           path: |
             Debug/*.a
             Release/*.a

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Archive Libraries
         uses: actions/upload-artifact@v3
         with:
-          name: Libraries
+          name: Windows-Libraries
           path: |
             x86/Debug/*.lib
             x64/Debug/*.lib


### PR DESCRIPTION
Giving the Linux and Windows versions the same name results in one version overwriting the other when uploaded.