### PR TITLE
Remove some linefeeds

### DIFF
--- a/Dir.cpp
+++ b/Dir.cpp
@@ -1139,7 +1139,7 @@ TInt RDir::read(TEntryArray *&a_rpoEntries, enum TDirSortOrder a_eSortOrder)
 						}
 						else
 						{
-							Utils::info("RDir::read() => Unable to allocate buffer to resolve link size\n");
+							Utils::info("RDir::read() => Unable to allocate buffer to resolve link size");
 						}
 					}
 					else
@@ -1221,7 +1221,7 @@ TInt RDir::read(TEntryArray *&a_rpoEntries, enum TDirSortOrder a_eSortOrder)
 				{
 					RetVal = KErrGeneral;
 
-					Utils::info("RDir::read() => ExAll() failed, IoErr() = %ld\n", IoErr);
+					Utils::info("RDir::read() => ExAll() failed, IoErr() = %ld", IoErr);
 
 					break;
 				}
@@ -1320,7 +1320,7 @@ TInt RDir::read(TEntryArray *&a_rpoEntries, enum TDirSortOrder a_eSortOrder)
 							}
 							else
 							{
-								Utils::info("RDir::read() => Unable to allocate buffer to resolve link size\n");
+								Utils::info("RDir::read() => Unable to allocate buffer to resolve link size");
 							}
 						}
 						else

--- a/StdTextFile.cpp
+++ b/StdTextFile.cpp
@@ -60,7 +60,7 @@ TInt RTextFile::open(const char *a_pccFileName)
 	}
 	else
 	{
-		Utils::info("RTextFile::open() => Unable to read in file \"%s\"\n", a_pccFileName);
+		Utils::info("RTextFile::open() => Unable to read in file \"%s\"", a_pccFileName);
 	}
 
 	return(RetVal);


### PR DESCRIPTION
Utils::info() automatically adds a linefeed when it prints a message, so there is no need for client code to do this.