### PR TITLE
Switch Amiga OS3 build to use newlib

### DIFF
--- a/makefile
+++ b/makefile
@@ -27,6 +27,7 @@ ifdef PREFIX
 		LFLAGS += -athread=native
 		OBJ := $(OBJ)_OS4
 	else
+		IFLAGS += -mcrt=nix20
 		AUTO_LIBRARY = $(OBJ)/libauto.a
 	endif
 endif


### PR DESCRIPTION
Exceptions are currently broken on the clib2 support library, and using newlib results in smaller binaries.