### PR TITLE
Make munge size a multiple of 8

### DIFF
--- a/MungWall.h
+++ b/MungWall.h
@@ -43,7 +43,9 @@
 
 #ifdef __cplusplus
 
-#define MungeSize 100
+/* This must be a multiple of 8, to avoid alignment problems on some 64 bit CPUs */
+
+#define MungeSize 96
 
 class MungWall
 {


### PR DESCRIPTION
Having a munge size of 100 was causing crashes on 64 bit ARM systems.