### PR TITLE
Add support for 64 bit file sizes

### DIFF
--- a/Dir.cpp
+++ b/Dir.cpp
@@ -318,11 +318,11 @@ void TEntry::Reset()
 
 /* Written: Saturday 03-Nov-2007 6:42 pm */
 
-void TEntry::Set(TBool a_bIsDir, TBool a_bIsLink, TUint a_uiSize, TUint a_uiAttributes, const TDateTime &a_roDateTime)
+void TEntry::Set(TBool a_bIsDir, TBool a_bIsLink, TInt64 a_iSize, TUint a_uiAttributes, const TDateTime &a_roDateTime)
 {
 	iIsDir = a_bIsDir;
 	iIsLink = a_bIsLink;
-	iSize = a_uiSize;
+	iSize = a_iSize;
 	iAttributes = a_uiAttributes;
 	iModified = a_roDateTime;
 
@@ -401,11 +401,11 @@ TInt TEntryArray::CompareEntries(const TEntry *a_poFirst, const TEntry *a_poSeco
 	}
 	else if (SortInfo->m_eSortOrder == EDirSortSizeAscending)
 	{
-		RetVal = (a_poFirst->iSize - a_poSecond->iSize);
+		RetVal = static_cast<TInt>(a_poFirst->iSize - a_poSecond->iSize);
 	}
 	else if (SortInfo->m_eSortOrder == EDirSortSizeDescending)
 	{
-		RetVal = (a_poSecond->iSize - a_poFirst->iSize);
+		RetVal = static_cast<TInt>(a_poSecond->iSize - a_poFirst->iSize);
 	}
 	else if (SortInfo->m_eSortOrder == EDirSortDateAscending)
 	{

--- a/Dir.h
+++ b/Dir.h
@@ -39,7 +39,7 @@ public:
 												 filled out by Utils::GetFileInfo(), not by methods in RDir */
 	TBool				iIsDir;				/**< ETrue if entry is a directory */
 	TBool				iIsLink;			/**< ETrue if entry is a link */
-	TUint				iSize;				/**< File size in bytes */
+	TInt64				iSize;				/**< File size in bytes */
 	TUint				iAttributes;		/**< Protection attributes, in Amiga/UNIX/Windows format */
 	TTime				iModified;			/**< Time and date of the file */
 
@@ -81,7 +81,7 @@ public:
 
 	void Reset();
 
-	void Set(TBool a_bIsDir, TBool a_bIsLink, TUint a_uiSize, TUint a_uiAttributes, const TDateTime &a_oDateTime);
+	void Set(TBool a_bIsDir, TBool a_bIsLink, TInt64 a_iSize, TUint a_uiAttributes, const TDateTime &a_oDateTime);
 };
 
 /* An instance of this class represents a number of TEntry classes and is filled */

--- a/MungWall.cpp
+++ b/MungWall.cpp
@@ -345,6 +345,14 @@ void *MungWall::New(size_t stSize, const char *pccSourceFile, int iSourceLine)
 	void *pvRetVal = NULL;
 	struct Arena *paBlock;
 
+	/* Account for the wraparound that will happen on 32 bit systems, if someone tries to allocate a */
+	/* very large amount of memory, such as 0xffffffff bytes */
+
+	if (stMungedSize < stSize)
+	{
+		return(NULL);
+	}
+
 	if (bEnableProfiling)
 	{
 		++ulNumProfiledNews;

--- a/RemoteFileUtils.cpp
+++ b/RemoteFileUtils.cpp
@@ -164,7 +164,7 @@ int RRemoteFileUtils::getFileInfo(const char *a_fileName, TEntry *a_entry)
 		{
 			SFileInfo *fileInfo = reinterpret_cast<SFileInfo *>(handler->getResponsePayload());
 			SWAP64(&fileInfo->m_microseconds);
-			SWAP(&fileInfo->m_size);
+			SWAP64(&fileInfo->m_size);
 
 			TDateTime dateTime(fileInfo->m_microseconds);
 

--- a/Yggdrasil/Commands.h
+++ b/Yggdrasil/Commands.h
@@ -98,7 +98,7 @@ struct SFileInfo
 	TInt64			m_microseconds;	/**< Timestamp of the file, in microseconds since 01.01.01 */
 	unsigned int	m_isDir;		/**< True if the file system object is a directory */
 	unsigned int	m_isLink;		/**< True if the file system object is a link */
-	unsigned int	m_size;			/**< File size in bytes */
+	TInt64			m_size;			/**< File size in bytes */
 	char			m_fileName[1];	/**< The file's name, without a path component */
 };
 


### PR DESCRIPTION
The TEntry.iSize field is now a 64 bit integer, and is filled out correctly on all platforms apart from Amiga OS.  This was implemented to support transferring of files larger than 4GB in RADRunner.  Methods that use this field, such as the Yggdrasil support methods, have also been updated.