### PR TITLE
Update RDir for 64 bit file sizes

### DIFF
--- a/Dir.cpp
+++ b/Dir.cpp
@@ -576,7 +576,7 @@ TInt RDir::AppendDirectoryEntry(WIN32_FIND_DATA *a_poFindData)
 				/* And populate the TEntry structure with the rest of the information */
 
 				Entry->Set((a_poFindData->dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY), (a_poFindData->dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT),
-					a_poFindData->nFileSizeLow, a_poFindData->dwFileAttributes, DateTime);
+					(TInt64) a_poFindData->nFileSizeHigh << 32 | a_poFindData->nFileSizeLow, a_poFindData->dwFileAttributes, DateTime);
 				Entry->iPlatformDate = a_poFindData->ftLastWriteTime;
 			}
 			else
@@ -1439,6 +1439,11 @@ TInt RDir::read(TEntryArray *&a_rpoEntries, enum TDirSortOrder a_eSortOrder)
 						break;
 					}
 				}
+
+				/* Reset errno before calling readdir() again, in case it was set by another function call while */
+				/* scanning the directory */
+
+				errno = 0;
 			}
 
 			/* Free the temporary buffer.  This is done outside the loop so that the originally allocated */

--- a/Yggdrasil/Commands.h
+++ b/Yggdrasil/Commands.h
@@ -31,11 +31,31 @@
 	(*(Source + 2) << 8) | \
 	*(Source + 3)
 
+#define READ_INT_64(Dest, Source) \
+	Dest = ((TInt64) *Source << 56) | \
+	((TInt64) *(Source + 1) << 48) | \
+	((TInt64) *(Source + 2) << 40) | \
+	((TInt64) *(Source + 3) << 32) | \
+	((TInt64) *(Source + 4) << 24) | \
+	((TInt64) *(Source + 5) << 16) | \
+	((TInt64) *(Source + 6) << 8) | \
+	(TInt64) *(Source + 7)
+
 #define WRITE_INT(Dest, Value) \
 	*Dest = (Value >> 24) & 0xff; \
 	*(Dest + 1) = (Value >> 16) & 0xff; \
 	*(Dest + 2) = (Value >> 8) & 0xff; \
 	*(Dest + 3) = Value & 0xff
+
+#define WRITE_INT_64(Dest, Value) \
+	*Dest = (Value >> 56) & 0xff; \
+	*(Dest + 1) = (Value >> 48) & 0xff; \
+	*(Dest + 2) = (Value >> 40) & 0xff; \
+	*(Dest + 3) = (Value >> 32) & 0xff; \
+	*(Dest + 4) = (Value >> 24) & 0xff; \
+	*(Dest + 5) = (Value >> 16) & 0xff; \
+	*(Dest + 6) = (Value >> 8) & 0xff; \
+	*(Dest + 7) = Value & 0xff
 
 /**
  * The commands supported by the program.

--- a/Yggdrasil/Handler.cpp
+++ b/Yggdrasil/Handler.cpp
@@ -280,7 +280,7 @@ int CHandler::sendFile(const char *a_fileName)
 			TInt64 total = ((endTime - startTime) / 1000);
 
 			/* Cast 64 bit results to integers when printing as Amiga OS doesn't support 64 bit format specifiers */
-			printf("%s: Transferred %d.%d Kilobytes in %d.%d seconds\n", g_commandNames[m_command.m_command], 
+			printf("%s: Transferred %d.%d Kilobytes in %d.%d seconds\n", g_commandNames[m_command.m_command],
 				static_cast<int>(entry.iSize / 1024), static_cast<int>(entry.iSize % 1024),
 				static_cast<int>(total / 1000), static_cast<int>(total % 1000));
 


### PR DESCRIPTION
During the initial 64 bit implementation, Utils::GetFileInfo() was updated, but not RDir.