### PR TITLE
Disable tabbing between widgets

### DIFF
--- a/Qt/QtGadgetTree.cpp
+++ b/Qt/QtGadgetTree.cpp
@@ -16,6 +16,7 @@ void CQtTreeWidget::construct(const std::string &a_title)
 	/* Set some sensible default settings, such as the number of columns to display */
 	setColumnCount(1);
 	setHeaderLabel(a_title.c_str());
+	setFocusPolicy(Qt::NoFocus);
 	setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 
 	/* And connect the itemClicked() slot so that we are notified when an item is clicked */

--- a/Qt/QtWindow.cpp
+++ b/Qt/QtWindow.cpp
@@ -40,9 +40,9 @@ CQtWindow::CQtWindow(CWindow *a_poWindow, QSize &a_roSize)
 	m_poWindow = a_poWindow;
 	m_oSize = a_roSize;
 
-	/* Allow the window to accept keyboard input by default */
+	/* Disable tabbing between widgets that are dynamically laid out */
 
-	setFocusPolicy(Qt::StrongFocus);
+	setFocusPolicy(Qt::NoFocus);
 }
 
 /**


### PR DESCRIPTION
Tabbing between widgets is undesirable when using dynamially added widgets.  It is useful in requesters, but for dynamic widgets, it is better to leave the tabbing to the application.