### PR TITLE
Call observer when no data is received

### DIFF
--- a/Qt/QtLocalSocket.cpp
+++ b/Qt/QtLocalSocket.cpp
@@ -73,6 +73,17 @@ void RLocalSocket::Connected()
 				}
 			}
 		}
+		else
+		{
+			/* A connection was made, but no data was sent with it.  In this case, we still want to notify the */
+			/* observer so that, for example, the client application listening on the socket can be brought */
+			/* to the front */
+
+			if (m_poObserver)
+			{
+				m_poObserver->MessageReceived(NULL, 0);
+			}
+		}
 
 		delete ClientSocket;
 	}


### PR DESCRIPTION
The RLocalSocket implementation for Qt now calls the observer when a connection is received, even if no data was received with that connection.  This enables the use case on macOS of running Brunel with no parameters, in order to bring Brunel to the front.