### PR TITLE
Add CStdGadgetLayout::remove(CStdGadget *) method

### DIFF
--- a/StdGadgetLayout.cpp
+++ b/StdGadgetLayout.cpp
@@ -487,11 +487,54 @@ void CStdGadgetLayout::ReAttach(CStdGadget *a_poGadget)
 
 /**
  * Remove a gadget from the layout.
- * This function will remove the gadget passed in from the layout.  This will take care of removing the gadget from
- * the layout's internal list of gadgets, as well as removing it from the underlying OS specific layout system.
+ * This function will remove the gadget passed in from the layout.  This will take care of removing the
+ * gadget from the layout's internal list of gadgets, as well as removing it from the underlying OS specific
+ * layout system.
+ *
+ * @date	Friday 29-Dec-2023 5:11 pm, Code HQ @ Ashley's house
+ * @param	a_poGadget		Pointer to the gadget to remove from the layout
+ */
+
+void CStdGadgetLayout::remove(CStdGadget *a_poGadget)
+{
+	ASSERTM((a_poGadget != NULL), "CStdGadgetLayout::remove() => No gadget to be removed passed in");
+
+	/* Remove the layout gadget from this layout's private list of layout gadgets */
+
+	m_oGadgets.remove(a_poGadget);
+
+#ifdef __amigaos__
+
+	/* And remove the BOOPSI gadget from the layout */
+
+	if (SetGadgetAttrs((struct Gadget *) m_poGadget, m_poParentWindow->m_poWindow, NULL,
+					   LAYOUT_RemoveChild, (ULONG) a_poGadget->m_poGadget, TAG_DONE))
+	{
+		if (m_bEnableRefresh)
+		{
+			rethinkLayout();
+		}
+	}
+
+#elif defined(WIN32) && !defined(QT_GUI_LIB)
+
+	/* And rethink the layout to reflect the change.  Qt will do this via a QEvent::LayoutRequest in */
+	/* its event filter so no need to do it for Qt */
+
+	rethinkLayout();
+
+#endif /* defined(WIN32) && !defined(QT_GUI_LIB) */
+
+}
+
+/**
+ * Remove a layout gadget from the layout.
+ * This function will remove the layout gadget passed in from the layout.  This will take care of removing the
+ * gadget from the layout's internal list of layouts, as well as removing it from the underlying OS specific
+ * layout system.
  *
  * @date	Thursday 15-Jul-2021 7:20 am, Code HQ Bergmannstrasse
- * @param	a_poGadget		Pointer to the gadget to remove from the layout
+ * @param	a_poLayoutGadget	Pointer to the gadget to remove from the layout
  */
 
 void CStdGadgetLayout::remove(CStdGadgetLayout *a_poLayoutGadget)

--- a/StdGadgets.h
+++ b/StdGadgets.h
@@ -152,11 +152,11 @@ private:
 
 #ifdef __amigaos__
 
-	Object					*m_poLayout;			/**< Pointer to the underlying Amiga OS gadget */
+	Object						*m_poLayout;		/**< Pointer to the underlying Amiga OS gadget */
 
 #elif defined(QT_GUI_LIB)
 
-	QBoxLayout				*m_poLayout;			/**< Pointer to the underlying Qt widget.
+	QBoxLayout					*m_poLayout;		/**< Pointer to the underlying Qt widget.
 														 Usually this is stored in m_poGadget but unfortunately
 														 QLayout derived objects do not derive from QWidget */
 
@@ -226,6 +226,8 @@ public:
 	void ReAttach(CStdGadget *a_poGadget);
 
 #endif /* __amigaos__ */
+
+	void remove(CStdGadget *a_poGagdet);
 
 	void remove(CStdGadgetLayout *a_poLayoutGadget);
 


### PR DESCRIPTION
This method is not currently used, but has been added for consistency.