### PR TITLE
Rename CQtTreeWidget to CQtGadgetTree

### DIFF
--- a/Qt/QtGadgetTree.cpp
+++ b/Qt/QtGadgetTree.cpp
@@ -11,7 +11,7 @@
  * @param	a_title			Title to be displayed at the top of the tree's column
  */
 
-void CQtTreeWidget::construct(const std::string &a_title)
+void CQtGadgetTree::construct(const std::string &a_title)
 {
 	/* Set some sensible default settings, such as the number of columns to display */
 	setColumnCount(1);
@@ -31,7 +31,7 @@ void CQtTreeWidget::construct(const std::string &a_title)
  * @date	Friday 13-Aug-2021 5:33 pm, Code HQ @ Thomas's House
  */
 
-void CQtTreeWidget::itemClicked()
+void CQtGadgetTree::itemClicked()
 {
 	m_parentTree->GetParentWindow()->HandleCommand(m_parentTree->GetGadgetID());
 }

--- a/Qt/QtGadgetTree.h
+++ b/Qt/QtGadgetTree.h
@@ -15,7 +15,7 @@ class CWindow;
  * user selecting an item, so that we can pass them onto the framework.
  */
 
-class CQtTreeWidget : public QTreeWidget
+class CQtGadgetTree : public QTreeWidget
 {
 	Q_OBJECT
 
@@ -25,7 +25,7 @@ private:
 
 public:
 
-	CQtTreeWidget(CStdGadgetTree *a_parentTree) : m_parentTree(a_parentTree) { }
+	CQtGadgetTree(CStdGadgetTree *a_parentTree) : m_parentTree(a_parentTree) { }
 
 	void construct(const std::string &a_title);
 

--- a/StdGadgets.h
+++ b/StdGadgets.h
@@ -410,7 +410,7 @@ private:
 
 #elif defined(QT_GUI_LIB)
 
-	CQtTreeWidget	m_tree;					/**< Helper class for listening for signals */
+    CQtGadgetTree	m_tree;					/**< Helper class for listening for signals */
 
 #endif /* QT_GUI_LIB */
 


### PR DESCRIPTION
The class was inconsistently named, so it has now been renamed to match the other classes in the Qt directory.