### PR TITLE
Add ability to show and hide the tree gadget

### DIFF
--- a/StdGadgetLayout.cpp
+++ b/StdGadgetLayout.cpp
@@ -478,7 +478,10 @@ void CStdGadgetLayout::ReAttach(CStdGadget *a_poGadget)
 		if (SetGadgetAttrs((struct Gadget *) m_poGadget, m_poParentWindow->m_poWindow, NULL,
 			LAYOUT_AddChild, (ULONG) a_poGadget->m_poGadget, TAG_DONE))
 		{
-			rethinkLayout();
+			if (m_bEnableRefresh)
+			{
+				rethinkLayout();
+			}
 		}
 	}
 }
@@ -790,8 +793,10 @@ bool CStdGadgetLayout::SetWeight(TInt a_iWeight)
 
 	if (m_poParentWindow)
 	{
+		ULONG WeightTag = (m_iGadgetType == EStdGadgetHorizontalLayout) ? CHILD_WeightedWidth: CHILD_WeightedHeight;
+
 		SetGadgetAttrs((struct Gadget *) m_poParentLayout->m_poGadget, m_poParentWindow->m_poWindow, NULL,
-			LAYOUT_ModifyChild, (ULONG) m_poGadget, CHILD_WeightedHeight, a_iWeight, TAG_DONE);
+			LAYOUT_ModifyChild, (ULONG) m_poGadget, WeightTag, a_iWeight, TAG_DONE);
 	}
 
 #elif defined(QT_GUI_LIB)

--- a/StdGadgetSlider.cpp
+++ b/StdGadgetSlider.cpp
@@ -488,10 +488,6 @@ void CStdGadgetSlider::SetRange(TInt a_iPageSize, TInt a_iMaxRange)
  * This enables slider gadgets to be hidden and unhidden on Amiga OS, even though the underlying Reaction system
  * does not support this functionality.
  *
- * Consideration needs to be given to the gadget's position in the parent layout's list of gadgets.  It will be
- * added to the *end* of the list of gadgets, which is not necessarily the same relative position that the gadget
- * had before it was hidden.
- *
  * @date	Sunday 04-Jul-2021 8:03 am, Code HQ Bergmannstrasse
  * @param	a_bVisible		true to make gadget visible, else false to hide it
  */
@@ -516,7 +512,7 @@ void CStdGadgetSlider::SetVisible(bool a_bVisible)
 		}
 	}
 
-	/* Just pass the call through to the super method to hide the gadget */
+	/* Otherwise just pass the call through to the super method to hide the gadget */
 
 	else
 	{

--- a/StdGadgets.h
+++ b/StdGadgets.h
@@ -176,7 +176,6 @@ private:
 		m_poParentLayout = a_poParentLayout;
 		m_poParentWindow = a_poParentWindow;
 		m_poClient = a_poClient;
-		m_iWeight = 50;
 	}
 
 	TInt Construct(bool a_bUseParentWindow);
@@ -442,6 +441,8 @@ protected:
 
 	int construct(const std::string &a_title);
 
+	bool createNative();
+
 public:
 
 	std::string getSelectedItem();
@@ -449,6 +450,13 @@ public:
 	void setContent(StdList<CTreeNode> &a_items);
 
 	void setTitle(const std::string &a_title);
+
+#ifdef __amigaos__
+
+	void SetVisible(bool a_bVisible) override;
+
+#endif /* __amigaos__ */
+
 };
 
 /* Mixin class for the slider or proportional gadget to be able to notify its client */


### PR DESCRIPTION
The tree gadget can now be hidden and shown again, even on Amiga OS, where it gets destroyed when it is removed, and must be recreated when being re-added.