### PR TITLE
Add move semantics support to StdList

### DIFF
--- a/StdList.h
+++ b/StdList.h
@@ -27,7 +27,7 @@ class StdList
 
 	typedef TInt (*CompareFunction)(const T *a_poFirst, const T *a_poSecond, void *a_pvUserData);
 
-private:
+public:
 
 	StdListNode<T>			m_oHead;		/**< Dummy node representing head of the list */
 	StdListNode<T>			m_oTail;		/**< Dummy node representing tail of the list */
@@ -39,6 +39,50 @@ public:
 	{
 		Reset();
 	};
+
+	/* Written: Tuesday 29-Feb-2024 7:30 am, Code HQ Tokyo Tsukuda */
+
+	StdList(StdList &&a_oOther)
+	{
+		*this = std::move(a_oOther);
+	};
+
+	/**
+	 * Move assignment operator.
+	 * The move assignment operator implements move semantics for the StdList class when using the = operator.  It
+	 * allows interoperation with the STL container classes.
+	 *
+	 * @date	Tuesday 29-Feb-2024 7:31 am, Code HQ Tokyo Tsukuda
+	 * @param	a_oOther		An instance of the list to be moved into this instance
+	 * @return	A reference to this list instance
+	 */
+
+	StdList &operator=(StdList &&a_oOther)
+	{
+		m_oHead = a_oOther.m_oHead;
+		m_oTail = a_oOther.m_oTail;
+		m_iCount = a_oOther.m_iCount;
+
+		if (m_oHead.m_poNext == &a_oOther.m_oTail)
+		{
+			m_oHead.m_poNext = &m_oTail;
+			m_oTail.m_poPrev = &m_oHead;
+		}
+		else
+		{
+			m_oHead.m_poNext = a_oOther.m_oHead.m_poNext;
+			m_oTail.m_poPrev = a_oOther.m_oTail.m_poPrev;
+			a_oOther.m_oHead.m_poNext = &a_oOther.m_oTail;
+			a_oOther.m_oTail.m_poPrev = &a_oOther.m_oHead;
+
+			m_oHead.m_poNext->m_poPrev = &m_oHead;
+			m_oTail.m_poPrev->m_poNext = &m_oTail;
+
+			a_oOther.m_iCount = 0;
+		}
+
+		return(*this);
+	}
 
 	void addHead(T *a_poNode)
 	{

--- a/Tests/T_StdList.cpp
+++ b/Tests/T_StdList.cpp
@@ -2,6 +2,7 @@
 #include <StdFuncs.h>
 #include <StdList.h>
 #include <Test.h>
+#include <string.h>
 
 static RTest Test("T_StdList");	/* Class to use for testing and reporting results */
 
@@ -151,7 +152,7 @@ static void TestIndex()
 	CNode *Node;
 	StdList<CNode> List;
 
-	/* Test #6: Test array style indexing functionality */
+	/* Test #5: Test array style indexing functionality */
 
 	Test.Next("Test array style indexing functionality");
 
@@ -223,6 +224,112 @@ static void TestMove()
 	FreeList(List);
 }
 
+StdList<CNode> GetList()
+{
+	CNode *Node;
+	StdList<CNode> RetVal;
+
+	Node = new CNode("Move it!");
+	test(Node != NULL);
+	RetVal.addTail(Node);
+
+	return RetVal;
+}
+
+/* Written: Thursday 29-Feb-2024 7:04 am, Code HQ Tokyo Tsukuda */
+
+void TestMoveSemantics()
+{
+	CNode *Node;
+	StdList<CNode> List1, Source1, Source2, Source3, Source4, Source5;
+
+	Test.Next("Test C++ move constructor semantics are respected");
+
+	List1 = std::move(Source1);
+	test(Source1.m_oHead.m_poNext == &Source1.m_oTail);
+	test(Source1.m_oTail.m_poPrev == &Source1.m_oHead);
+	test(Source1.Count() == 0);
+	test(List1.m_oHead.m_poNext == &List1.m_oTail);
+	test(List1.m_oTail.m_poPrev == &List1.m_oHead);
+	test(List1.Count() == 0);
+
+	Node = new CNode("Move it!");
+	test(Node != NULL);
+	Source1.addTail(Node);
+
+	List1 = std::move(Source1);
+	test(Source1.m_oHead.m_poNext == &Source1.m_oTail);
+	test(Source1.m_oTail.m_poPrev == &Source1.m_oHead);
+	test(Source1.Count() == 0);
+	test(List1.m_oHead.m_poNext == &Node->m_oStdListNode);
+	test(List1.m_oTail.m_poPrev == &Node->m_oStdListNode);
+	test(Node->m_oStdListNode.m_poPrev == &List1.m_oHead);
+	test(Node->m_oStdListNode.m_poNext == &List1.m_oTail);
+	test(List1.Count() == 1);
+
+	Test.Next("Test C++ move assignment operator semantics are respected");
+
+	StdList<CNode> List2 = std::move(Source2);
+	test(Source2.m_oHead.m_poNext == &Source2.m_oTail);
+	test(Source2.m_oTail.m_poPrev == &Source2.m_oHead);
+	test(Source2.Count() == 0);
+	test(List2.m_oHead.m_poNext == &List2.m_oTail);
+	test(List2.m_oTail.m_poPrev == &List2.m_oHead);
+	test(List2.Count() == 0);
+
+	Source3.addTail(Node);
+
+	StdList<CNode> List3(std::move(Source3));
+	test(Source3.m_oHead.m_poNext == &Source3.m_oTail);
+	test(Source3.m_oTail.m_poPrev == &Source3.m_oHead);
+	test(Source3.Count() == 0);
+	test(List3.m_oHead.m_poNext == &Node->m_oStdListNode);
+	test(List3.m_oTail.m_poPrev == &Node->m_oStdListNode);
+	test(Node->m_oStdListNode.m_poPrev == &List3.m_oHead);
+	test(Node->m_oStdListNode.m_poNext == &List3.m_oTail);
+	test(List3.Count() == 1);
+
+	Test.Next("Test StdList.remHead() functions when move semantics are used");
+
+	Source4.addTail(Node);
+
+	StdList<CNode> List4(std::move(Source4));
+
+	FreeList(List4);
+	test(List4.m_oHead.m_poNext == &List4.m_oTail);
+	test(List4.m_oTail.m_poPrev == &List4.m_oHead);
+	test(List4.Count() == 0);
+
+	Test.Next("Test StdList.getHead() functions when move semantics are used");
+
+	Node = new CNode("Move it!");
+	test(Node != NULL);
+	Source5.addTail(Node);
+
+	StdList<CNode> List5(std::move(Source5));
+
+	while ((Node = List5.getHead()) != NULL)
+	{
+		List5.remove(Node);
+		delete Node;
+	}
+
+	test(List5.m_oHead.m_poNext == &List5.m_oTail);
+	test(List5.m_oTail.m_poPrev == &List5.m_oHead);
+	test(List5.Count() == 0);
+
+	Test.Next("Test returning a list instance by value when move semantics are used");
+
+	StdList<CNode> List6 = GetList();
+	test(List6.m_oHead.m_poNext != &List6.m_oTail);
+	test(List6.m_oTail.m_poPrev != &List6.m_oHead);
+	test(List6.m_oHead.m_poNext->m_poPrev == &List6.m_oHead);
+	test(List6.m_oTail.m_poPrev->m_poNext == &List6.m_oTail);
+	test(List6.Count() == 1);
+
+	FreeList(List6);
+}
+
 /* Written: Friday 27-Jun-2014 7:12 am, Code HQ Ehinger Tor */
 
 static void TestSort()
@@ -258,6 +365,7 @@ int main()
 	TestMove();
 	TestSort();
 	TestIndex();
+	TestMoveSemantics();
 
 	Test.End();
 

--- a/Tests/makefile
+++ b/Tests/makefile
@@ -39,7 +39,8 @@ ifdef PREFIX
 	endif
 endif
 
-EXECUTABLES = $(T_ARGS) $(T_CONFIGFILE) $(T_DIR) $(T_FILE) $(T_LEX) $(T_POOL) $(T_STDTEXTFILE) $(T_STRINGLIST) $(T_TIME) $(T_UTILS) $(T_WILDCARD)
+EXECUTABLES = $(T_ARGS) $(T_CONFIGFILE) $(T_DIR) $(T_FILE) $(T_LEX) $(T_POOL) $(T_STDLIST) $(T_STDTEXTFILE) \
+	$(T_STRINGLIST) $(T_TIME) $(T_UTILS) $(T_WILDCARD)
 
 ifdef PREFIX
 
@@ -60,6 +61,8 @@ T_LEX = $(OBJ)/T_Lex
 T_OS4SUPPORT = $(OBJ)/T_OS4Support
 
 T_POOL = $(OBJ)/T_Pool
+
+T_STDLIST = $(OBJ)/T_StdList
 
 T_STDTEXTFILE = $(OBJ)/T_StdTextFile
 
@@ -84,6 +87,8 @@ T_LEX_OBJECTS = $(OBJ)/T_Lex.o
 T_OS4SUPPORT_OBJECTS = $(OBJ)/T_OS4Support.o
 
 T_POOL_OBJECTS = $(OBJ)/T_Pool.o
+
+T_STDLIST_OBJECTS = $(OBJ)/T_StdList.o
 
 T_STDTEXTFILE_OBJECTS = $(OBJ)/T_StdTextFile.o
 
@@ -133,6 +138,11 @@ $(T_OS4SUPPORT): $(T_OS4SUPPORT_OBJECTS) ../$(OBJ)/libStdFuncs.a
 $(T_POOL): $(T_POOL_OBJECTS) ../$(OBJ)/libStdFuncs.a
 	@echo Linking $@...
 	$(LD) $(T_POOL_OBJECTS) $(LFLAGS) $(LIBS) -o $@.debug
+	$(STRIP) $(STRIP_FLAGS) $@.debug -o $@
+
+$(T_STDLIST): $(T_STDLIST_OBJECTS) ../$(OBJ)/libStdFuncs.a
+	@echo Linking $@...
+	$(LD) $(T_STDLIST_OBJECTS) $(LFLAGS) $(LIBS) -o $@.debug
 	$(STRIP) $(STRIP_FLAGS) $@.debug -o $@
 
 $(T_STDTEXTFILE): $(T_STDTEXTFILE_OBJECTS) ../$(OBJ)/libStdFuncs.a


### PR DESCRIPTION
The StdList class now has a move constructor and a move assignment operator, and can be safely used in conjunction with the STL container classes that require move semantics.