### PR TITLE
Move varargs wrappers into OS4Support.cpp

### DIFF
--- a/OS4Support.cpp
+++ b/OS4Support.cpp
@@ -69,6 +69,22 @@ APTR AllocSysObject(ULONG a_type, const struct TagItem *a_tags)
 }
 
 /**
+ * Convenience wrapper around AllocSysObject.
+ * This wrapper simply takes the pointer to the list of tags passed in on the stack and calls AllocSysObject
+ * using them.
+ *
+ * @date	Monday 15-Apr-2024 6:02 am, Code HQ Tokyo Tsukuda
+ * @param	a_type			The type of object to be allocated, such as ASOT_PORT
+ * @param	a_tag			The first tag of the stack-based list of tags to use
+ * @return	The return value from AllocSysObject
+ */
+
+APTR AllocSysObjectTags(ULONG a_type, Tag a_tag, ...)
+{
+	return AllocSysObject(a_type, (struct TagItem *) &a_tag);
+}
+
+/**
  * Converts a BCPL string to a C string.
  * Safely copies a BSTR into a user supplied buffer, NULL terminating it at the appropriate length, and checking
  * that the string is able to fit into the target buffer.
@@ -176,4 +192,23 @@ void RefreshSetGadgetAttrsA(struct Gadget *a_gadget, struct Window *a_window, st
 	{
 		RefreshGList(a_gadget, a_window, a_requester, 1);
 	}
+}
+
+/**
+ * Convenience wrapper around RefreshSetGadgetAttrs.
+ * This wrapper simply takes the pointer to the list of tags passed in on the stack and calls RefreshSetGadgetAttrs
+ * using them.
+ *
+ * @date	Monday 15-Apr-2024 6:10 am, Code HQ Tokyo Tsukuda
+ * @param	a_gadget		Pointer to the BOOPSI gadget object
+ * @param	a_window		Pointer to the window in which the gadget resides, or NULL
+ * @param	a_requester		Pointer to the requester in which the gadget resides, or NULL
+ * @param	a_tag			The first tag of the stack-based list of tags to use
+ * @return	The return value from RefreshSetGadgetAttrs
+ */
+
+void RefreshSetGadgetAttrs(struct Gadget *a_gadget, struct Window *a_window, struct Requester *a_requester,
+	Tag a_tag, ...)
+{
+	RefreshSetGadgetAttrsA(a_gadget, a_window, a_requester, (struct TagItem *) &a_tag);
 }

--- a/OS4Support.h
+++ b/OS4Support.h
@@ -6,13 +6,6 @@
 
 #if defined(__amigaos__) && !defined(__amigaos4__)
 
-APTR AllocSysObject(ULONG a_type, const struct TagItem *a_tags);
-ULONG CopyStringBSTRToC(BSTR a_bstring, STRPTR a_dest, ULONG a_size);
-ULONG DateStampToSeconds(const struct DateStamp *a_dateStamp);
-void FreeSysObject(ULONG a_type, APTR a_object);
-void RefreshSetGadgetAttrsA(struct Gadget *a_gadget, struct Window *a_window, struct Requester *a_requester,
-	struct TagItem *a_taglist);
-
 /* New entries in dos/dos.h */
 
 #define EXDB_NO_READ		3
@@ -43,26 +36,15 @@ enum enAllocSysObjectTypes
 	ASOT_SEMAPHORE	= 8
 };
 
-inline APTR AllocSysObjectTags(ULONG a_type, Tag a_tag, ...)
-{
-	va_list args;
-
-	va_start(args, a_tag);
-	APTR retVal = AllocSysObject(a_type, (struct TagItem *) &a_tag);
-	va_end(args);
-
-	return retVal;
-}
-
-inline void RefreshSetGadgetAttrs(struct Gadget *a_gadget, struct Window *a_window, struct Requester *a_requester,
-	Tag a_tag, ...)
-{
-	va_list args;
-
-	va_start(args, a_tag);
-	RefreshSetGadgetAttrsA(a_gadget, a_window, a_requester, (struct TagItem *) &a_tag);
-	va_end(args);
-}
+APTR AllocSysObject(ULONG a_type, const struct TagItem *a_tags);
+APTR AllocSysObjectTags(ULONG a_type, Tag a_tag, ...);
+ULONG CopyStringBSTRToC(BSTR a_bstring, STRPTR a_dest, ULONG a_size);
+ULONG DateStampToSeconds(const struct DateStamp *a_dateStamp);
+void FreeSysObject(ULONG a_type, APTR a_object);
+void RefreshSetGadgetAttrsA(struct Gadget *a_gadget, struct Window *a_window, struct Requester *a_requester,
+	struct TagItem *a_taglist);
+void RefreshSetGadgetAttrs(struct Gadget *a_gadget, struct Window *a_window, struct Requester *a_requester,
+	Tag a_tag, ...);
 
 #endif /* defined(__amigaos__) && !defined(__amigaos4__) */
 


### PR DESCRIPTION
In release mode, the compiler was being too aggressive in its optimisation of the use of the varargs-based OS4 wrapper functions, causing them to not work. Moving them into the .cpp file solves this problem.