### PR TITLE
Add a call to CWindow::InternalRedraw()

### DIFF
--- a/StdWindow.cpp
+++ b/StdWindow.cpp
@@ -1861,6 +1861,10 @@ void CWindow::DrawNow(TInt a_iTop, TInt a_iBottom)
 
 			m_oDirtyRegions.push_back(Region);
 		}
+
+		/* And actually perform the redraw */
+
+		InternalRedraw();
 	}
 
 #elif defined(QT_GUI_LIB)


### PR DESCRIPTION
This call was missing on Amiga OS, meaning that calls to the CWindow::DrawNow() method wouldn't actually do anything until later on, when some other event occurred that triggered a redraw.