### PR TITLE
Get rendezvous working on Windows

### DIFF
--- a/Qt/QtLocalSocket.cpp
+++ b/Qt/QtLocalSocket.cpp
@@ -284,6 +284,9 @@ TInt RLocalSocket::write(const unsigned char *a_pcucData, TInt a_iDataSize)
 	{
 		RetVal = KErrNone;
 
+		/* Although calling waitForBytesWritten() shouldn't be necessary, it is required for Windows */
+
+		m_oLocalSocket.waitForBytesWritten();
 		m_oLocalSocket.flush();
 	}
 	else


### PR DESCRIPTION
The Qt version of RRendezvous was not working on Windows, due to a possible bug or implementation detail on the Windows version of the QLocalSocket class. It requires that the waitForBytesWritten() method is called, or no data will be sent to the target socket.