### PR TITLE
Enable focus-related events on Qt

### DIFF
--- a/Qt/QtWindow.cpp
+++ b/Qt/QtWindow.cpp
@@ -39,10 +39,6 @@ CQtWindow::CQtWindow(CWindow *a_poWindow, QSize &a_roSize)
 {
 	m_poWindow = a_poWindow;
 	m_oSize = a_roSize;
-
-	/* Disable tabbing between widgets that are dynamically laid out */
-
-	setFocusPolicy(Qt::NoFocus);
 }
 
 /**

--- a/StdWindow.cpp
+++ b/StdWindow.cpp
@@ -2633,6 +2633,12 @@ TInt CWindow::open(const char *a_pccTitle, const char *a_pccScreenName, TBool a_
 
 					m_poWindow->showMaximized();
 
+					/* Showing the window doesn't necessarily give it focus, even if keyboard input to the window is */
+					/* working, meaning that the window won't get focus-related events. Explicitly setting the focus */
+					/* to the window shouldn't be necessary, but seems to be required to enable these events to be sent */
+
+					m_poWindow->setFocus();
+
 					/* Save the outer width and height of the window */
 
 					Size = m_poWindow->size();


### PR DESCRIPTION
Qt's widget focus handling can be a bit tricky. Recent architectural changes related to the file list broke it, and these changes are required to get it working again.