### PR TITLE
Add support for multiple screens

### DIFF
--- a/Qt/QtWindow.cpp
+++ b/Qt/QtWindow.cpp
@@ -32,13 +32,17 @@ static const SKeyMapping g_aoKeyMap[] =
  *
  * @date	Friday 27-Sep-2019 3:02 pm, HERE Invalidenstrasse
  * @param	a_poWindow		Pointer to the parent Framework window
+ * @param	a_roPosition	The position at which to create the new window
  * @param	a_roSize		The size of the new window to be created
  */
 
-CQtWindow::CQtWindow(CWindow *a_poWindow, QSize &a_roSize)
+CQtWindow::CQtWindow(CWindow *a_poWindow, QPoint &a_roPosition, QSize &a_roSize)
 {
 	m_poWindow = a_poWindow;
 	m_oSize = a_roSize;
+
+	move(a_roPosition);
+	resize(a_roSize);
 }
 
 /**

--- a/Qt/QtWindow.h
+++ b/Qt/QtWindow.h
@@ -64,7 +64,7 @@ protected:
 
 public:
 
-	CQtWindow(CWindow *a_poWindow, QSize &a_roSize);
+	CQtWindow(CWindow *a_poWindow, QPoint &a_roPosition, QSize &a_roSize);
 
 	CWindow *Window()
 	{


### PR DESCRIPTION
When a top level window is opened, the position of the mouse pointer will be checked and, if it is on a different screen to the main one, the window will be opened on that screen instead of the main screen.