### PR TITLE
Use Mac OS 13 for building

### DIFF
--- a/.github/workflows/macos_qt.yml
+++ b/.github/workflows/macos_qt.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - name: Checkout


### PR DESCRIPTION
The Xcode version used in the Mac OS 14 runners was upgrade to 15.4 beta, which has broken Qt 5.15.2 builds.