### PR TITLE
Add a KErrNotOpen error to StdFuncs.h

### DIFF
--- a/StdFuncs.h
+++ b/StdFuncs.h
@@ -109,6 +109,7 @@ typedef signed long long TInt64;
 #define KErrWrite			-23
 #define KErrEof				-25
 #define KErrHostNotFound	-26
+#define KErrNotOpen			-27
 
 /* Useful macros for the WinMain() and main() functions, enabling them to be used */
 /* without #ifdefs in portable code */

--- a/StdSocket.cpp
+++ b/StdSocket.cpp
@@ -60,6 +60,7 @@ RSocket::RSocket()
  * @return	KErrNone if successful
  * @return	KErrGeneral if the socket could not be opened
  * @return	KErrHostNotFound if the host could not be resolved
+ * @return	KErrNotOpen if a connection to the remote server could not be made
  */
 
 int RSocket::open(const char *a_host, unsigned short a_port)
@@ -95,6 +96,10 @@ int RSocket::open(const char *a_host, unsigned short a_port)
 					{
 						retVal = KErrNone;
 					}
+					else
+					{
+						retVal = KErrNotOpen;
+					}
 				}
 				else
 				{
@@ -113,6 +118,11 @@ int RSocket::open(const char *a_host, unsigned short a_port)
 				}
 			}
 		}
+	}
+
+	if (retVal != KErrNone)
+	{
+		close();
 	}
 
 	return retVal;


### PR DESCRIPTION
This makes it easier to differentiate between a generic socket failure and a socket failure that was caused when a connection cannot be made.