### PR TITLE
Get the Qt version working on Windows again

### DIFF
--- a/StdApplication.cpp
+++ b/StdApplication.cpp
@@ -751,9 +751,9 @@ void RApplication::exit()
 
 	m_bDone = ETrue;
 
-#elif defined(__unix__)
+#elif defined(QT_GUI_LIB)
 
-	m_poApplication->quit();
+	m_poApplication->exit();
 
 #else /* ! __unix__ */
 


### PR DESCRIPTION
With the upgrade to Qt6, the Windows version of Brunel stopped exiting, and it's difficult to see how it ever worked to begin with, even with Qt5. This commit also addresses a problem whereby Brunel would ask twice whether to save a file that had been edited, due to changes in the way the quit functionality is implemented on Qt6.