### PR TITLE
Add support for paths in Utils::splitHost()

### DIFF
--- a/Tests/T_Utils.cpp
+++ b/Tests/T_Utils.cpp
@@ -466,6 +466,34 @@ int main()
 	Result = Utils::StringToInt("", &Value);
 	test(Result == KErrCorrupt);
 
+	/* Test #16: Utils::splitHost() tests */
+
+	Test.Next("Utils::splitHost() tests");
+
+	std::string Server;
+	int PathOffset;
+	unsigned short Port;
+
+	test(Utils::splitHost("www.example.com", Server, Port, 80) == KErrNone);
+	test(Server == "www.example.com");
+	test(Port == 80);
+
+	test(Utils::splitHost("www.example.com:8080", Server, Port, 80) == KErrNone);
+	test(Server == "www.example.com");
+	test(Port == 8080);
+
+	test(Utils::splitHost("", Server, Port, 80) == KErrNotFound);
+
+	PathOffset = Utils::splitHost("www.example.com/path", Server, Port, 80);
+	test(Server == "www.example.com");
+	test(Port == 80);
+	test(PathOffset == 16);
+
+	PathOffset = Utils::splitHost("www.example.com:8080/path", Server, Port, 80);
+	test(Server == "www.example.com");
+	test(Port == 8080);
+	test(PathOffset == 21);
+
 	/* Clean up after ourselves */
 
 	Result = g_oFileUtils.deleteFile("TimeFile.txt");

--- a/Utils.h
+++ b/Utils.h
@@ -109,7 +109,7 @@ public:
 
 	static TInt setProtection(const char *a_pccFileName, TUint a_uiAttributes);
 
-	static int splitHost(const char *a_pccHost, std::string &a_roServer, unsigned short &a_rusPort, unsigned short a_usDefaultPort = 80);
+	static int splitHost(const char *a_host, std::string &a_server, unsigned short &a_port, unsigned short a_defaultPort = 80);
 
 	static char *StripDags(char *a_pcLine, TInt *a_piLength);
 


### PR DESCRIPTION
If a path was present after the hostname, and there was no port specified, an incorrect hostname would be returned to the caller.