### PR TITLE
Clear file list after use

### DIFF
--- a/Dir.cpp
+++ b/Dir.cpp
@@ -955,9 +955,7 @@ TInt RDir::open(const char *a_pccPattern)
 
 void RDir::close()
 {
-	/* Free the contents of the TEntry array in case it the RDir class is reused */
-
-	m_entries.Purge();
+	RDirObject::close();
 
 #ifdef __amigaos__
 

--- a/Dir.h
+++ b/Dir.h
@@ -135,7 +135,12 @@ public:
 
 	virtual TInt open(const char *a_pattern) = 0;
 
-	virtual void close() = 0;
+	virtual void close()
+	{
+		/* Free the contents of the TEntry array in case the RDir class is reused */
+
+		m_entries.Purge();
+	}
 
 	virtual TInt read(TEntryArray *&a_entries, enum TDirSortOrder a_sortOrder = EDirSortNone) = 0;
 };

--- a/RemoteDir.h
+++ b/RemoteDir.h
@@ -25,8 +25,6 @@ public:
 
 	int open(const char *a_pattern);
 
-	void close() { }
-
 	int read(TEntryArray *&a_entries, enum TDirSortOrder a_sortOrder = EDirSortNone);
 
 	void setFactory(RRemoteFactory *a_remoteFactory) { m_remoteFactory = a_remoteFactory; }

--- a/RemoteFileUtils.cpp
+++ b/RemoteFileUtils.cpp
@@ -163,7 +163,7 @@ int RRemoteFileUtils::deleteFile(const char *a_fileName)
 
 int RRemoteFileUtils::getFileInfo(const char *a_fileName, TEntry *a_entry)
 {
-	ASSERTM((a_entry != nullptr), "RRemoteFileUtils::getFileInfo() => Pointer to filename passed in must not be NULL");
+	ASSERTM((a_fileName!= nullptr), "RRemoteFileUtils::getFileInfo() => Pointer to filename passed in must not be NULL");
 	ASSERTM((a_entry != nullptr), "RRemoteFileUtils::getFileInfo() => TEntry structure passed in must not be NULL");
 
 	RSocket socket;


### PR DESCRIPTION
The remote implementation of the RDirObject class was not clearing out its list when close() was called, resulting in duplicate entries in Brunel's FileTree.