### PR TITLE
Add missing header file

### DIFF
--- a/Dir.cpp
+++ b/Dir.cpp
@@ -10,6 +10,7 @@
 
 #include <errno.h>
 #include <fnmatch.h>
+#include <time.h>
 #include <sys/stat.h>
 
 #endif /* __unix__ */


### PR DESCRIPTION
The time.h header file is required to compile on the latest Ubuntu, even though it was working without this on previous versions.