### PR TITLE
Use persistent connection to server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ if(${Qt6_FOUND} EQUAL 1)
 
 	set(SourceFiles ${SourceFiles} "StdApplication.cpp")
 	set(SourceFiles ${SourceFiles} "RemoteDir.cpp")
+	set(SourceFiles ${SourceFiles} "RemoteFactory.cpp")
 	set(SourceFiles ${SourceFiles} "RemoteFile.cpp")
 	set(SourceFiles ${SourceFiles} "RemoteFileUtils.cpp")
 	set(SourceFiles ${SourceFiles} "StdCharConverter.cpp")

--- a/RemoteDir.cpp
+++ b/RemoteDir.cpp
@@ -51,18 +51,15 @@ int RRemoteDir::open(const char *a_pattern)
 {
 	(void) a_pattern;
 
-	RSocket socket;
-	int retVal = socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+	int retVal = KErrNone;
 
-	if (retVal == KErrNone)
+	if (m_socket->isOpen())
 	{
 		CDir *handler = nullptr;
 
 		try
 		{
-			socket.write(g_signature, SIGNATURE_SIZE);
-
-			handler = new CDir(&socket, a_pattern);
+			handler = new CDir(m_socket, a_pattern);
 			handler->sendRequest();
 
 			if (handler->getResponse()->m_result == KErrNone)
@@ -110,11 +107,13 @@ int RRemoteDir::open(const char *a_pattern)
 		}
 
 		delete handler;
-		socket.close();
 	}
 	else
 	{
-		Utils::info("RRemoteDir::open() => Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+		Utils::info("RRemoteDir::open() => Connection to server \"%s:%d\" is not open", m_remoteFactory->getServer().c_str(),
+			m_remoteFactory->getPort());
+
+		retVal = KErrNotOpen;
 	}
 
 	return retVal;

--- a/RemoteDir.h
+++ b/RemoteDir.h
@@ -18,16 +18,21 @@ class RRemoteFactory;
 class RRemoteDir : public RDirObject
 {
 	RRemoteFactory	*m_remoteFactory;	/**< Pointer to the remote factory that owns this instance */
+	RSocket			*m_socket;			/**< Socket for communicating with remote RADRunner */
 
 public:
 
-	RRemoteDir() : m_remoteFactory(nullptr) { }
+	RRemoteDir() : m_remoteFactory(nullptr), m_socket(nullptr) { }
 
 	int open(const char *a_pattern);
 
 	int read(TEntryArray *&a_entries, enum TDirSortOrder a_sortOrder = EDirSortNone);
 
-	void setFactory(RRemoteFactory *a_remoteFactory) { m_remoteFactory = a_remoteFactory; }
+	void setFactory(RRemoteFactory *a_remoteFactory, RSocket *a_socket)
+	{
+		m_remoteFactory = a_remoteFactory;
+		m_socket = a_socket;
+	}
 };
 
 #endif /* ! REMOTEDIR_H */

--- a/RemoteFactory.cpp
+++ b/RemoteFactory.cpp
@@ -1,0 +1,210 @@
+
+#include "StdFuncs.h"
+#include "RemoteFactory.h"
+
+#if defined(__unix__) || defined(__amigaos__)
+
+#include <fcntl.h>
+#include <sys/socket.h>
+
+#else /* ! defined(__unix__) || defined(__amigaos__) */
+
+#include <ws2tcpip.h>
+
+#endif /* ! defined(__unix__) || defined(__amigaos__) */
+
+/**
+ * Gets an object for directory manipulation.
+ * Returns an instance of a class derived from RDirObject which can be used to manipulate directories, either
+ * locally or remotely, depending on how the factory was configured.
+ *
+ * @date	Saturday 25-May-2024 8:27 am, Code HQ Tokyo Tsukuda
+ * @return	A reference to an RDirObject derived object
+ */
+
+RDirObject &RRemoteFactory::getDirObject()
+{
+	if (isRemote())
+	{
+		checkConnection();
+		m_remoteDir.setFactory(this, &m_socket);
+		return m_remoteDir;
+	}
+	else
+	{
+		return m_dir;
+	}
+}
+
+/**
+ * Gets an object for file manipulation.
+ * Returns an instance of a class derived from RFileObject which can be used to manipulate files, either
+ * locally or remotely, depending on how the factory was configured.
+ *
+ * @date	Saturday 25-May-2024 8:27 am, Code HQ Tokyo Tsukuda
+ * @return	A reference to an RFileObject derived object
+ */
+
+RFileObject &RRemoteFactory::getFileObject()
+{
+	if (isRemote())
+	{
+		checkConnection();
+		m_remoteFile.setFactory(this, &m_socket);
+		return m_remoteFile;
+	}
+	else
+	{
+		return m_file;
+	}
+}
+
+/**
+ * Gets an object for file system manipulation.
+ * Returns an instance of a class derived from RFileUtilsObject which can be used to manipulate file system
+ * objects, either locally or remotely, depending on how the factory was configured.
+ *
+ * @date	Saturday 25-May-2024 8:27 am, Code HQ Tokyo Tsukuda
+ * @return	A reference to an RFileUtilsObject derived object
+ */
+
+RFileUtilsObject &RRemoteFactory::getFileUtilsObject()
+{
+	if (isRemote())
+	{
+		checkConnection();
+		m_remoteFileUtils.setFactory(this, &m_socket);
+		return m_remoteFileUtils;
+	}
+	else
+	{
+		return m_fileUtils;
+	}
+}
+
+/**
+ * Open a connection to a remote RADRunner instance.
+ * This function can be called any time a connection to RADRunner needs to be made. It can be called either
+ * by client code at startup, or The Framework will do it automatically if a file request is made and it is
+ * detected that the connection has been lost.
+ *
+ * @pre		Server and port must have already been set
+ *
+ * @date	Saturday 11-May-2024 9:14 am, Enoshima holiday apartment
+ * @return	KErrNone if successful, otherwise one of the errors returned by RSocket::open()
+ */
+
+int RRemoteFactory::openRemote()
+{
+	int retVal = m_socket.open(getServer().c_str(), getPort());
+
+	if (retVal == KErrNone)
+	{
+		try
+		{
+			m_socket.write(g_signature, SIGNATURE_SIZE);
+		}
+		catch (RSocket::Error &a_exception)
+		{
+			Utils::info("RRemoteFactory::openRemote() => Unable to perform I/O on socket (Error = %d)", a_exception.m_result);
+		}
+	}
+
+	return retVal;
+}
+
+/**
+ * Close the remote factory.
+ * Closing the remote factory will also close any connected sockets.
+ *
+ * @date	Saturday 11-May-2024 9:16 am, Enoshima holiday apartment
+ */
+
+void RRemoteFactory::close()
+{
+	m_socket.close();
+}
+
+/**
+* Check connection and reopen if necessary.
+* This method is a part of the self-healing functionality of The Framework's socket system. It can be called at
+* any time, whether the socket has been connected previously or not. If the socket is closed, it will be opened.
+* If the socket is open, it will be checked to see if it is still connected. If it is not, it will be reconnected.
+*
+* @pre		Server and port must have already been set
+*
+* @date	Tuesday 14-May-2024 6:02 am, Code HQ Tokyo Tsukuda
+* @return	KErrNone if successful, otherwise one of the errors returned by RRemoteFactory::openRemote()
+*/
+
+// TODO: CAW - Move this stuff into RSocket?
+int RRemoteFactory::checkConnection()
+{
+	int retVal = KErrNone;
+
+	/* If the socket is open, it could be that the connection has been lost, so we'll check that by setting */
+	/* the socket to non-blocking and trying to read a byte. If it fails, it means the connection is closed. */
+	/* This trick depends on the remote server not sending data without being requested to */
+	if (m_socket.isOpen())
+	{
+		int result = 0;
+
+		/* Error handling is difficult here, as it is unlikely to fail unless an invalid socket is used, and if */
+		/* it does fail, there is not much we can do as this is supposed to be a transparent self-healing routine. */
+		/* So we'll check for errors and handle but not report them, and if the final call to set the socket back */
+		/* to blocking mode fails, all hell will break loose, but so be it */
+
+#ifdef WIN32
+
+		u_long blocking = 1;
+
+		if (ioctlsocket(m_socket.m_socket, FIONBIO, &blocking) == 0)
+		{
+			char buffer[1];
+			result = recv(m_socket.m_socket, buffer, 1, 0);
+
+			blocking = 0;
+
+			if (ioctlsocket(m_socket.m_socket, FIONBIO, &blocking) != 0)
+			{
+				result = -1;
+			}
+		}
+
+#else /* ! WIN32 */
+
+		int flags = fcntl(m_socket.m_socket, F_GETFL, 0);
+
+		if (flags != -1)
+		{
+			if (fcntl(m_socket.m_socket, F_SETFL, flags | O_NONBLOCK) != -1)
+			{
+				char buffer[1];
+				result = recv(m_socket.m_socket, buffer, 1, 0);
+
+				if (result != -1)
+				{
+					if (fcntl(m_socket.m_socket, F_SETFL, flags) == -1)
+					{
+						result = -1;
+					}
+				}
+			}
+		}
+
+#endif /* ! WIN32 */
+
+		if (result == 0)
+		{
+			close();
+
+			retVal = openRemote();
+		}
+	}
+	else
+	{
+		retVal = openRemote();
+	}
+
+	return retVal;
+}

--- a/RemoteFactory.h
+++ b/RemoteFactory.h
@@ -7,6 +7,7 @@
 #include "RemoteDir.h"
 #include "RemoteFile.h"
 #include "RemoteFileUtils.h"
+#include "Yggdrasil/Commands.h"
 
 /**
  * A class for management of file system related objects.
@@ -26,6 +27,7 @@ class RRemoteFactory
 	RRemoteFile			m_remoteFile;		/**< Class for remote file access */
 	RFileUtils			m_fileUtils;		/**< Class for local file system manipulation */
 	RRemoteFileUtils	m_remoteFileUtils;	/**< Class for remote file system manipulation */
+	RSocket				m_socket;			/**< Socket for communicating with remote RADRunner */
 	std::string			m_serverName;		/**< The host name of the instance of RADRunner to use */
 	unsigned short		m_serverPort;		/**< The port on which RADRunner is listening */
 
@@ -33,44 +35,17 @@ public:
 
 	RRemoteFactory() : m_useLocal(false) { }
 
-	RDirObject &getDirObject()
-	{
-		if (isRemote())
-		{
-			m_remoteDir.setFactory(this);
-			return m_remoteDir;
-		}
-		else
-		{
-			return m_dir;
-		}
-	}
+	int openRemote();
 
-	RFileObject &getFileObject()
-	{
-		if (isRemote())
-		{
-			m_remoteFile.setFactory(this);
-			return m_remoteFile;
-		}
-		else
-		{
-			return m_file;
-		}
-	}
+	void close();
 
-	RFileUtilsObject &getFileUtilsObject()
-	{
-		if (isRemote())
-		{
-			m_remoteFileUtils.setFactory(this);
-			return m_remoteFileUtils;
-		}
-		else
-		{
-			return m_fileUtils;
-		}
-	}
+	int checkConnection();
+
+	RDirObject &getDirObject();
+
+	RFileObject &getFileObject();
+
+	RFileUtilsObject &getFileUtilsObject();
 
 	bool isRemote()
 	{
@@ -87,6 +62,9 @@ public:
 		m_serverPort = a_port;
 	}
 
+	/**< Set this to true when the RRemoteFactory instance is configured to be used for remote
+	 * access, but there is a need to temporarily access the local file system
+	 */
 	void useLocal(bool a_useLocal)
 	{
 		m_useLocal = a_useLocal;

--- a/RemoteFile.h
+++ b/RemoteFile.h
@@ -23,7 +23,7 @@ class RRemoteFile : public RFileObject
 	bool						m_dirty;			/**< True if a write has been performed */
 	int							m_fileOffset;		/**< The current read/write offset into the file */
 	RRemoteFactory				*m_remoteFactory;	/**< Pointer to the remote factory that owns this instance */
-	RSocket						m_socket;			/**< Socket for communicating with remote RADRunner */
+	RSocket						*m_socket;			/**< Socket for communicating with remote RADRunner */
 	std::string					m_fileName;			/**< The name of the file on the remote server */
 	std::vector<unsigned char>	m_fileBuffer;		/**< Buffer containing the contents of the file */
 
@@ -31,7 +31,7 @@ class RRemoteFile : public RFileObject
 
 public:
 
-	RRemoteFile() : m_dirty(false), m_fileOffset(0), m_remoteFactory(nullptr) { }
+	RRemoteFile() : m_dirty(false), m_fileOffset(0), m_remoteFactory(nullptr), m_socket(nullptr) { }
 
 	int create(const char *a_fileName, TUint a_fileMode);
 
@@ -47,7 +47,11 @@ public:
 
 	int close();
 
-	void setFactory(RRemoteFactory *a_remoteFactory) { m_remoteFactory = a_remoteFactory; }
+	void setFactory(RRemoteFactory *a_remoteFactory, RSocket *a_socket)
+	{
+		m_remoteFactory = a_remoteFactory;
+		m_socket = a_socket;
+	}
 };
 
 #endif /* ! REMOTEFILE_H */

--- a/RemoteFileUtils.cpp
+++ b/RemoteFileUtils.cpp
@@ -108,18 +108,15 @@ TResult CRename::sendRequest()
 
 int RRemoteFileUtils::deleteFile(const char *a_fileName)
 {
-	RSocket socket;
-	int retVal = socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+	int retVal = KErrNone;
 
-	if (retVal == KErrNone)
+	if (m_socket->isOpen())
 	{
 		CDelete *handler = nullptr;
 
 		try
 		{
-			socket.write(g_signature, SIGNATURE_SIZE);
-
-			handler = new CDelete(&socket, a_fileName);
+			handler = new CDelete(m_socket, a_fileName);
 			handler->sendRequest();
 
 			if (handler->getResponse()->m_result != KErrNone)
@@ -137,11 +134,13 @@ int RRemoteFileUtils::deleteFile(const char *a_fileName)
 		}
 
 		delete handler;
-		socket.close();
 	}
 	else
 	{
-		Utils::info("RRemoteFileUtils::deleteFile() => Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+		Utils::info("RRemoteFileUtils::deleteFile() => Connection to server \"%s:%d\" is not open", m_remoteFactory->getServer().c_str(),
+			m_remoteFactory->getPort());
+
+		retVal = KErrNotOpen;
 	}
 
 	return retVal;
@@ -163,21 +162,18 @@ int RRemoteFileUtils::deleteFile(const char *a_fileName)
 
 int RRemoteFileUtils::getFileInfo(const char *a_fileName, TEntry *a_entry)
 {
-	ASSERTM((a_fileName!= nullptr), "RRemoteFileUtils::getFileInfo() => Pointer to filename passed in must not be NULL");
+	ASSERTM((a_fileName != nullptr), "RRemoteFileUtils::getFileInfo() => Pointer to filename passed in must not be NULL");
 	ASSERTM((a_entry != nullptr), "RRemoteFileUtils::getFileInfo() => TEntry structure passed in must not be NULL");
 
-	RSocket socket;
-	int retVal = socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+	int retVal = KErrNone;
 
-	if (retVal == KErrNone)
+	if (m_socket->isOpen())
 	{
 		CFileInfo *handler = nullptr;
 
 		try
 		{
-			socket.write(g_signature, SIGNATURE_SIZE);
-
-			handler = new CFileInfo(&socket, a_fileName);
+			handler = new CFileInfo(m_socket, a_fileName);
 			handler->sendRequest();
 
 			if (handler->getResponse()->m_result == KErrNone)
@@ -199,17 +195,20 @@ int RRemoteFileUtils::getFileInfo(const char *a_fileName, TEntry *a_entry)
 		}
 		catch (RSocket::Error &a_exception)
 		{
+			Utils::info("%s", a_exception.what());
 			Utils::info("RRemoteFileUtils::getFileInfo() => Unable to perform I/O on socket (Error = %d)", a_exception.m_result);
 
 			retVal = KErrNotFound;
 		}
 
 		delete handler;
-		socket.close();
 	}
 	else
 	{
-		Utils::info("RRemoteFileUtils::getFileInfo() => Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+		Utils::info("RRemoteFileUtils::getFileInfo() => Connection to server \"%s:%d\" is not open", m_remoteFactory->getServer().c_str(),
+			m_remoteFactory->getPort());
+
+		retVal = KErrNotOpen;
 	}
 
 	return retVal;
@@ -227,18 +226,15 @@ int RRemoteFileUtils::getFileInfo(const char *a_fileName, TEntry *a_entry)
 
 int RRemoteFileUtils::renameFile(const char *a_oldFullName, const char *a_newFullName)
 {
-	RSocket socket;
-	int retVal = socket.open(m_remoteFactory->getServer().c_str(), m_remoteFactory->getPort());
+	int retVal = KErrNone;
 
-	if (retVal == KErrNone)
+	if (m_socket->isOpen())
 	{
 		CRename *handler = nullptr;
 
 		try
 		{
-			socket.write(g_signature, SIGNATURE_SIZE);
-
-			handler = new CRename(&socket, a_oldFullName, a_newFullName);
+			handler = new CRename(m_socket, a_oldFullName, a_newFullName);
 			handler->sendRequest();
 
 			if (handler->getResponse()->m_result != KErrNone)
@@ -256,11 +252,13 @@ int RRemoteFileUtils::renameFile(const char *a_oldFullName, const char *a_newFul
 		}
 
 		delete handler;
-		socket.close();
 	}
 	else
 	{
-		Utils::info("RRemoteFileUtils::renameFile() => Cannot connect to %s (%d)", m_remoteFactory->getServer().c_str(), retVal);
+		Utils::info("RRemoteFileUtils::renameFile() => Connection to server \"%s:%d\" is not open", m_remoteFactory->getServer().c_str(),
+			m_remoteFactory->getPort());
+
+		retVal = KErrNotOpen;
 	}
 
 	return retVal;

--- a/RemoteFileUtils.h
+++ b/RemoteFileUtils.h
@@ -5,6 +5,7 @@
 /** @file */
 
 #include "FileUtils.h"
+#include "StdSocket.h"
 
 class RRemoteFactory;
 
@@ -16,10 +17,11 @@ class RRemoteFactory;
 class RRemoteFileUtils : public RFileUtilsObject
 {
 	RRemoteFactory	*m_remoteFactory;	/**< Pointer to the remote factory that owns this instance */
+	RSocket			*m_socket;			/**< Socket for communicating with remote RADRunner */
 
 public:
 
-	RRemoteFileUtils() : m_remoteFactory(nullptr) { }
+	RRemoteFileUtils() : m_remoteFactory(nullptr),m_socket(nullptr) { }
 
 	int deleteFile(const char *a_fileName);
 
@@ -27,7 +29,11 @@ public:
 
 	int renameFile(const char *a_oldFullName, const char *a_newFullName);
 
-	void setFactory(RRemoteFactory *a_remoteFactory) { m_remoteFactory = a_remoteFactory; }
+	void setFactory(RRemoteFactory *a_remoteFactory, RSocket *a_socket)
+	{
+		m_remoteFactory = a_remoteFactory;
+		m_socket = a_socket;
+	}
 };
 
 #endif /* ! REMOTEFILEUTILS_H */

--- a/StdFuncs.pro
+++ b/StdFuncs.pro
@@ -27,7 +27,7 @@ MOC_DIR = $$OBJECTS_DIR
 DEFINES -= UNICODE
 
 SOURCES += Args.cpp Dir.cpp File.cpp FileUtils.cpp Lex.cpp MungWall.cpp \
-    RemoteDir.cpp RemoteFile.cpp RemoteFileUtils.cpp Yggdrasil/Handler.cpp \
+    RemoteDir.cpp RemoteFactory.cpp RemoteFile.cpp RemoteFileUtils.cpp Yggdrasil/Handler.cpp \
 	StdApplication.cpp StdCharConverter.cpp StdClipboard.cpp StdConfigFile.cpp StdCRC.cpp StdDialog.cpp StdFileRequester.cpp \
 	StdFont.cpp StdGadgets.cpp StdGadgetLayout.cpp StdGadgetSlider.cpp StdGadgetStatusBar.cpp StdGadgetTree.cpp \
 	StdImage.cpp StdPool.cpp StdRendezvous.cpp StdSocket.cpp StdStringList.cpp StdTextFile.cpp StdTime.cpp \
@@ -35,9 +35,9 @@ SOURCES += Args.cpp Dir.cpp File.cpp FileUtils.cpp Lex.cpp MungWall.cpp \
 
 SOURCES += Qt/QtAction.cpp Qt/QtGadgetSlider.cpp Qt/QtGadgetTree.cpp Qt/QtLocalSocket.cpp Qt/QtWindow.cpp
 
-HEADERS += Args.h Dir.h File.h FileUtils.h Lex.h MungWall.h StdApplication.h StdCharConverter.h StdClipboard.h \
-	StdConfigFile.h StdDialog.h StdFileRequester.h StdFont.h StdFuncs.h StdGadgets.h StdImage.h StdList.h \
-	StdPool.h StdReaction.h StdRendezvous.h StdSocket.h StdStringList.h StdTextFile.h StdTime.h StdWildcard.h \
-	StdWindow.h Test.h Utils.h
+HEADERS += Args.h Dir.h File.h FileUtils.h Lex.h MungWall.h RemoteDir.cpp RemoteFactory.cpp RemoteFile.cpp RemoteFileUtils.cpp \
+	StdApplication.h StdCharConverter.h StdClipboard.h StdConfigFile.h StdDialog.h StdFileRequester.h StdFont.h StdFuncs.h \
+	StdGadgets.h StdImage.h StdList.h StdPool.h StdReaction.h StdRendezvous.h StdSocket.h StdStringList.h StdTextFile.h StdTime.h \
+	StdWildcard.h StdWindow.h Test.h Utils.h
 
 HEADERS += Qt/QtAction.h Qt/QtGadgetSlider.h Qt/QtGadgetTree.h Qt/QtLocalSocket.h Qt/QtWindow.h

--- a/StdFuncs.vcxproj
+++ b/StdFuncs.vcxproj
@@ -209,6 +209,7 @@
     <ClCompile Include="Lex.cpp" />
     <ClCompile Include="MungWall.cpp" />
     <ClCompile Include="RemoteDir.cpp" />
+    <ClCompile Include="RemoteFactory.cpp" />
     <ClCompile Include="RemoteFile.cpp" />
     <ClCompile Include="RemoteFileUtils.cpp" />
     <ClCompile Include="StdApplication.cpp" />

--- a/StdSocket.cpp
+++ b/StdSocket.cpp
@@ -99,6 +99,8 @@ int RSocket::open(const char *a_host, unsigned short a_port)
 					else
 					{
 						retVal = KErrNotOpen;
+
+						close();
 					}
 				}
 				else
@@ -186,6 +188,19 @@ int RSocket::accept()
 	}
 
 	return retVal;
+}
+
+/**
+ * Indicates whether the socket is open.
+ * Returns a boolean indicating whether the socket is open and connected to a remote server.
+ *
+ * @date	Tuesday 14-May-2024 6:41 am, Code HQ Tokyo Tsukuda
+ * @return	true if the socket is open, else false
+ */
+
+bool RSocket::isOpen()
+{
+	return m_socket != INVALID_SOCKET;
 }
 
 /**

--- a/StdSocket.h
+++ b/StdSocket.h
@@ -62,6 +62,8 @@ public:
 
 	int accept();
 
+	bool isOpen();
+
 	int listen(unsigned short a_port);
 
 	int read(void* a_buffer, int a_size, bool a_readAll = true);

--- a/makefile
+++ b/makefile
@@ -35,7 +35,7 @@ LIBRARY = $(OBJ)/libStdFuncs.a
 
 ifdef PREFIX
 	OBJECTS = $(OBJ)/AmiMenus.o $(OBJ)/Args.o $(OBJ)/Dir.o $(OBJ)/File.o $(OBJ)/FileUtils.o $(OBJ)/Lex.o $(OBJ)/MungWall.o \
-		$(OBJ)/RemoteDir.o $(OBJ)/RemoteFile.o $(OBJ)/RemoteFileUtils.o \
+		$(OBJ)/RemoteDir.o $(OBJ)/RemoteFactory.o $(OBJ)/RemoteFile.o $(OBJ)/RemoteFileUtils.o \
 		$(OBJ)/StdApplication.o $(OBJ)/StdCharConverter.o $(OBJ)/StdClipboard.o $(OBJ)/StdConfigFile.o $(OBJ)/StdCRC.o $(OBJ)/StdDialog.o \
 		$(OBJ)/StdFileRequester.o $(OBJ)/StdFont.o $(OBJ)/StdGadgets.o $(OBJ)/StdGadgetLayout.o $(OBJ)/StdGadgetSlider.o \
 		$(OBJ)/StdGadgetStatusBar.o $(OBJ)/StdGadgetTree.o $(OBJ)/StdImage.o $(OBJ)/StdPool.o $(OBJ)/StdRendezvous.o $(OBJ)/StdSocket.o \
@@ -52,7 +52,7 @@ ifdef PREFIX
 	endif
 else
 	OBJECTS = $(OBJ)/Args.o $(OBJ)/StdCharConverter.o $(OBJ)/Dir.o $(OBJ)/File.o $(OBJ)/FileUtils.o $(OBJ)/Lex.o $(OBJ)/MungWall.o \
-		$(OBJ)/RemoteDir.o $(OBJ)/RemoteFile.o $(OBJ)/RemoteFileUtils.o \
+		$(OBJ)/RemoteDir.o $(OBJ)/RemoteFactory.o $(OBJ)/RemoteFile.o $(OBJ)/RemoteFileUtils.o \
 		$(OBJ)/StdConfigFile.o $(OBJ)/StdCRC.o $(OBJ)/StdPool.o $(OBJ)/StdRendezvous.o $(OBJ)/StdSocket.o $(OBJ)/StdStringList.o \
 		$(OBJ)/StdTextFile.o $(OBJ)/StdTime.o $(OBJ)/StdWildcard.o $(OBJ)/Test.o $(OBJ)/Utils.o
 endif


### PR DESCRIPTION
To speed up file operations when a remote server is in use, the connection to that server is now held open and reused, rather than a new connection being created for every file operation.