### PR TITLE
Use a use count for sockets on Windows

### DIFF
--- a/StdSocket.h
+++ b/StdSocket.h
@@ -41,6 +41,12 @@ public:
 
 private:
 
+#ifdef WIN32
+
+	static int	m_useCount;		/**< Number of times the socket has been opened */
+
+#endif /* WIN32 */
+		
 	SOCKET	m_serverSocket;		/**< The socket on which to listen for connections */
 
 public:


### PR DESCRIPTION
In order to ensure that WSACleanup() is not called for sockets that have never been opened, use a use count when opening and closing sockets and call WSACleanup() only when it reaches 0.