### PR TITLE
Save the content ID of the item list in use

### DIFF
--- a/StdGadgetTree.cpp
+++ b/StdGadgetTree.cpp
@@ -180,6 +180,8 @@ void CStdGadgetTree::setContent(int a_contentID)
 {
 	ASSERTM((a_contentID >= 0), "CStdGadgetTree::setContent() => Invalid content ID passed in");
 
+	m_contentID = a_contentID;
+
 #ifdef __amigaos__
 
 	SetGadgetAttrs((struct Gadget *) m_poGadget, NULL, NULL, LISTBROWSER_Labels, (ULONG) NULL, TAG_DONE);
@@ -282,7 +284,9 @@ int CStdGadgetTree::setContent(StdList<CTreeNode> &a_items)
 
 #endif /* ! QT_GUI_LIB */
 
-	return m_nextContentID++;
+	m_contentID = m_nextContentID++;
+
+	return m_contentID;
 }
 
 /**

--- a/StdGadgets.h
+++ b/StdGadgets.h
@@ -412,6 +412,7 @@ class CStdGadgetTree : public CStdGadget
 {
 private:
 
+	int		m_contentID;					/**< The content ID of the file list currently in use */
 	int		m_nextContentID;				/**< The next content ID that will be assigned to a new list */
 
 #ifdef __amigaos__
@@ -465,6 +466,11 @@ protected:
 	int setContent(StdList<CTreeNode> &a_items);
 
 public:
+
+	int getContentID()
+	{
+		return m_contentID;
+	}
 
 	std::string getSelectedItem();
 


### PR DESCRIPTION
The content ID of the current item list is now saved and exposed via the getContentID() method, to enable client code to more easily manipulate the currently displayed list.