### PR TITLE
Fix problem with long lines getting clipped

### DIFF
--- a/StdFont.cpp
+++ b/StdFont.cpp
@@ -1001,7 +1001,7 @@ void RFont::DrawColouredText(const char *a_pccText, TInt a_iStartOffset, TInt a_
 		XPixels = TextWidthInPixels(LineText);
 		XPosition = (m_iXOffset + XPixels);
 
-		if (XPosition > m_iClipWidth)
+		if (XPixels > m_iClipWidth)
 		{
 			break;
 		}


### PR DESCRIPTION
Line length calculations were incorrectly taking the space used up by the file list into account when calculating available space. This led to long lines being clipped, leaving white space on the right of the line instead of text being printed.