### PR TITLE
Add support for Rust parsing

### DIFF
--- a/Lex.h
+++ b/Lex.h
@@ -28,8 +28,8 @@ private:
 
 	const char	*m_pccString;			/**< Ptr to string to be parsed by non destructive routine */
 	const char	*m_pccOriginalString;	/**< Cached copy of m_pccString */
-	const char	*m_pccQuotes;			/**< Quote characters for which to check */
 	const char	*m_pccWhitespace;		/**< Whitespace characters for which to check */
+	char		m_acQuotes[3];			/**< Quote characters for which to check */
 	char		*m_pcString;			/**< Ptr to string to be parsed by destructive routine */
 	TBool		m_bKeepQuotes;			/**< ETrue to keep the quote marks around strings */
 	TBool		m_bKeepWhitespace;		/**< ETrue to treat white space as a token */

--- a/StdConfigFile.cpp
+++ b/StdConfigFile.cpp
@@ -774,6 +774,10 @@ TInt RConfigFile::Parse()
 
 				Lex.SetWhitespace(" \t=");
 
+				/* Don't use any quotes, because the token itself might contain some that we want to use */
+
+				Lex.SetQuotes("");
+
 				/* Get the first token from the line */
 
 				if ((Token = Lex.NextToken(&TokenLength)) != NULL)

--- a/Tests/T_Lex.cpp
+++ b/Tests/T_Lex.cpp
@@ -80,9 +80,9 @@ static const char* g_accOnlyEndQuoteResults[] = { "One\"" };
 static const char g_accOnlyStartQuoteNonAlphaNum[] = "\"One!";
 static const char* g_accOnlyStartQuoteNonAlphaNumResults[] = { "\"One!" };
 
-#define ONLY_END_QUOTE_ALPHA_NUM_COUNT 1
+#define ONLY_END_QUOTE_ALPHA_NUM_COUNT 2
 static const char g_accOnlyEndQuoteNonAlphaNum[] = "One!\"";
-static const char* g_accOnlyEndQuoteNonAlphaNumResults[] = { "One!\"" };
+static const char* g_accOnlyEndQuoteNonAlphaNumResults[] = { "One", "!\""};
 
 /* Written: Saturday 17-Nov-2012 7:22 pm, Code HQ Ehinger Tor */
 /* @param	a_roLex			Reference to the initialised TLex object to be tested */
@@ -298,7 +298,7 @@ int main()
 	TLex OnlyEndQuoteNonAlphaNum(g_accOnlyEndQuoteNonAlphaNum, (int) strlen(g_accOnlyEndQuoteNonAlphaNum));
 	OnlyEndQuoteNonAlphaNum.SetConfig(ETrue, ETrue, ETrue);
 	OnlyEndQuoteNonAlphaNum.SetQuotes(QuoteChars);
-	CheckListNonDestructive(OnlyEndQuoteNonAlphaNum, g_accOnlyEndQuoteNonAlphaNumResults, ONLY_END_QUOTE_COUNT);
+	CheckListNonDestructive(OnlyEndQuoteNonAlphaNum, g_accOnlyEndQuoteNonAlphaNumResults, ONLY_END_QUOTE_ALPHA_NUM_COUNT);
 
 	TLex OnlyStartQuoteNonAlphaNum_NA(g_accOnlyStartQuoteNonAlphaNum, (int) strlen(g_accOnlyStartQuoteNonAlphaNum));
 	OnlyStartQuoteNonAlphaNum_NA.SetConfig(ETrue, ETrue, ETrue);
@@ -307,7 +307,7 @@ int main()
 	TLex OnlyEndQuoteNonAlphaNum_NA(g_accOnlyEndQuoteNonAlphaNum, (int) strlen(g_accOnlyEndQuoteNonAlphaNum));
 	OnlyEndQuoteNonAlphaNum_NA.SetConfig(ETrue, ETrue, ETrue);
 	OnlyEndQuoteNonAlphaNum_NA.SetQuotes(QuoteChars);
-	CheckListNonDestructive(OnlyEndQuoteNonAlphaNum_NA, g_accOnlyEndQuoteNonAlphaNumResults, ONLY_END_QUOTE_COUNT);
+	CheckListNonDestructive(OnlyEndQuoteNonAlphaNum_NA, g_accOnlyEndQuoteNonAlphaNumResults, ONLY_END_QUOTE_ALPHA_NUM_COUNT);
 
 	Test.End();
 


### PR DESCRIPTION
Fix a bug that was preventing us from configuraing the TLex class from using a single quote character. This is required for Rust support, where the ' character is not a quote.