### PR TITLE
Treat '_' as an alphanumeric character

### DIFF
--- a/Lex.cpp
+++ b/Lex.cpp
@@ -313,9 +313,9 @@ const char *TLex::NextToken(TInt *a_piLength)
 
 		else
 		{
-			if (isalnum((unsigned char) *NextToken))
+			if (IsAlNum((unsigned char) *NextToken))
 			{
-				while ((Index < m_iLength) && isalnum((unsigned char) *NextToken) && !IsWhitespace(*NextToken) &&
+				while ((Index < m_iLength) && IsAlNum((unsigned char) *NextToken) && !IsWhitespace(*NextToken) &&
 					(!IsQuote(*NextToken)))
 				{
 					++NextToken;
@@ -324,7 +324,7 @@ const char *TLex::NextToken(TInt *a_piLength)
 			}
 			else
 			{
-				while ((Index < m_iLength) && !isalnum((unsigned char) *NextToken) && !IsWhitespace(*NextToken) &&
+				while ((Index < m_iLength) && !IsAlNum((unsigned char) *NextToken) && !IsWhitespace(*NextToken) &&
 					!IsQuote(*NextToken))
 				{
 					++NextToken;

--- a/Lex.h
+++ b/Lex.h
@@ -39,6 +39,13 @@ private:
 	TInt		m_iQuotesLength;		/**< Number of characters of quotes to be checked */
 	TInt		m_iWhitespaceLength;	/**< Number of characters of white space to be checked */
 
+private:
+
+	inline bool IsAlNum(unsigned char a_character)
+	{
+		return (a_character == '_') ? true : isalnum(a_character);
+	}
+
 public:
 
 	TLex(const char *a_pccString, TInt a_iLength);


### PR DESCRIPTION
Variable names that contained the '_' character were being broken up into multiple subtokens by the highlighter, due to the highlighter's special assembly language support. This character is now treated as a normal alphanumeric character, to avoid this.