### PR TITLE
Fix some OS4 compilation errors

### DIFF
--- a/Args.cpp
+++ b/Args.cpp
@@ -90,9 +90,9 @@ TInt RArgs::open(const char *a_pccTemplate, TInt a_iNumOptions, const char *a_pc
 
 				for (Index = 1; Index < a_iArgC; ++Index)
 				{
-					if (strstr(a_pccArgV[Index], " ") > NULL) strcat(m_pcArgumentBuffer, "\"");
+					if (strstr(a_pccArgV[Index], " ") != NULL) strcat(m_pcArgumentBuffer, "\"");
 					strcat(m_pcArgumentBuffer, a_pccArgV[Index]);
-					if (strstr(a_pccArgV[Index], " ") > NULL) strcat(m_pcArgumentBuffer, "\"");
+					if (strstr(a_pccArgV[Index], " ") != NULL) strcat(m_pcArgumentBuffer, "\"");
 
 					/* If this is not the last argument, append a space to it */
 

--- a/File.cpp
+++ b/File.cpp
@@ -4,7 +4,11 @@
 #include "FileUtils.h"
 #include <string.h>
 
-#ifdef __unix__
+#ifdef __amigaos__
+
+#include "OS4Support.h"
+
+#elif defined(__unix__)
 
 #include <errno.h>
 #include <fcntl.h>

--- a/OS4Support.h
+++ b/OS4Support.h
@@ -50,9 +50,15 @@ void RefreshSetGadgetAttrs(struct Gadget *a_gadget, struct Window *a_window, str
 
 #ifdef __amigaos4__
 
-/* Functions renamed in OS4 but still compatible with their OS3 equivalents */
+/* Functions pointlessly renamed in OS4 but still compatible with their OS3 equivalents */
 
 #define GetCurrentDirName(buffer, length) GetCliCurrentDirName(buffer, length)
+
+#ifndef Seek
+
+#define Seek(file, position, mode) ChangeFilePosition(file, position, mode)
+
+#endif /* ! Seek */
 
 #endif /* __amigaos4__ */
 


### PR DESCRIPTION
The version of GCC used in the OS4 Docker image was updated, causing an error to appear due to an invalid comparison. Plus the dos.library maintainer has been up to his old tricks again, renaming DOS functions.