### PR TITLE
Fix unwanted file list resizing

### DIFF
--- a/Qt/QtGadgetTree.cpp
+++ b/Qt/QtGadgetTree.cpp
@@ -17,7 +17,7 @@ void CQtGadgetTree::construct(const std::string &a_title)
 	setColumnCount(1);
 	setHeaderLabel(a_title.c_str());
 	setFocusPolicy(Qt::NoFocus);
-	setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+	setSizePolicy(QSizePolicy::Minimum, QSizePolicy::MinimumExpanding);
 
 	/* And connect the itemClicked() slot so that we are notified when an item is clicked */
 	connect(this, SIGNAL(itemClicked(QTreeWidgetItem*, int)), SLOT(itemClicked()));


### PR DESCRIPTION
When the last file was closed, the file list would change size to only take up a small part of the screen, due to incorrect stretch parameters being passed in.