### PR TITLE
Update to v4 of actions/upload-artifact

### DIFF
--- a/.github/workflows/amiga_os3.yml
+++ b/.github/workflows/amiga_os3.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           command: "make DEBUG=1"
       - name: Archive Libraries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Amiga-Libraries-OS3
           path: |

--- a/.github/workflows/amiga_os4.yml
+++ b/.github/workflows/amiga_os4.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           command: "make DEBUG=1"
       - name: Archive Libraries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Amiga-Libraries-OS4
           path: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
           cd Tests
           for file in Debug/T_*.debug; do $file; done
       - name: Archive Libraries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux-Libraries
           path: |

--- a/.github/workflows/linux_qt.yml
+++ b/.github/workflows/linux_qt.yml
@@ -27,7 +27,7 @@ jobs:
           qmake
           make -f Makefile debug
       - name: Archive Libraries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Linux-Qt-Libraries
           path: |

--- a/.github/workflows/macos_qt.yml
+++ b/.github/workflows/macos_qt.yml
@@ -27,7 +27,7 @@ jobs:
           qmake
           make debug
       - name: Archive Libraries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: MacOS-Qt-Libraries
           path: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -100,7 +100,7 @@ jobs:
             }
           }
       - name: Archive Libraries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Windows-Libraries
           path: |

--- a/.github/workflows/windows_qt.yml
+++ b/.github/workflows/windows_qt.yml
@@ -28,7 +28,7 @@ jobs:
           qmake
           nmake debug
       - name: Archive Libraries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Windows-Qt-Libraries
           path: |


### PR DESCRIPTION
v3 has been deprecated by GitHub and no longer functions.