### PR TITLE
Add stack checking to MungWall

### DIFF
--- a/MungWall.h
+++ b/MungWall.h
@@ -60,17 +60,19 @@ class MungWall
 
 	BOOL bEnableOutput;
 	BOOL bEnableProfiling;
+	int iLowestStack;
 	ULONG ulNumProfiledNews;
 	ULONG ulNumNews;
 	struct Arena *paFirstArena;
 	BOOL CheckBlockValidity(void *);
 	ULONG CheckOverWrite(UBYTE *);
 	void CheckOverWrites(struct Arena *);
+	void CheckStack();
 	void MungeMem(uint32_t *, size_t);
 
 public:
 
-	MungWall() { bEnableOutput = TRUE; bEnableProfiling = FALSE; ulNumNews = 0; paFirstArena = NULL; }
+	MungWall();
 	~MungWall();
 
 	ULONG NumProfiledNews()

--- a/makefile
+++ b/makefile
@@ -52,9 +52,9 @@ ifdef PREFIX
 	endif
 else
 	OBJECTS = $(OBJ)/Args.o $(OBJ)/StdCharConverter.o $(OBJ)/Dir.o $(OBJ)/File.o $(OBJ)/FileUtils.o $(OBJ)/Lex.o $(OBJ)/MungWall.o \
-		$(OBJ)/RemoteDir.o $(OBJ)/RemoteFactory.o $(OBJ)/RemoteFile.o $(OBJ)/RemoteFileUtils.o \
-		$(OBJ)/StdConfigFile.o $(OBJ)/StdCRC.o $(OBJ)/StdPool.o $(OBJ)/StdRendezvous.o $(OBJ)/StdSocket.o $(OBJ)/StdStringList.o \
-		$(OBJ)/StdTextFile.o $(OBJ)/StdTime.o $(OBJ)/StdWildcard.o $(OBJ)/Test.o $(OBJ)/Utils.o
+		$(OBJ)/RemoteDir.o $(OBJ)/RemoteFactory.o $(OBJ)/RemoteFile.o $(OBJ)/RemoteFileUtils.o $(OBJ)/StdConfigFile.o $(OBJ)/StdCRC.o \
+		$(OBJ)/StdPool.o $(OBJ)/StdRendezvous.o $(OBJ)/StdSocket.o $(OBJ)/StdStringList.o $(OBJ)/StdTextFile.o $(OBJ)/StdTime.o \
+		$(OBJ)/StdWildcard.o $(OBJ)/Test.o $(OBJ)/Utils.o
 endif
 
 OBJECTS += $(OBJ)/Handler.o


### PR DESCRIPTION
Whenever an allocation is freed by MungWall, the stack pointer will be checked to ensure that it is within the stack bounds. Also, the largest amount of stack that has been used will be tracked, so that the developer can be notified if the stack is getting close to overflowing.