### PR TITLE
Change include guard of Commands.h

### DIFF
--- a/Yggdrasil/Commands.h
+++ b/Yggdrasil/Commands.h
@@ -1,6 +1,6 @@
 
-#ifndef COMMANDS_H
-#define COMMANDS_H
+#ifndef REMOTE_COMMANDS_H
+#define REMOTE_COMMANDS_H
 
 /** @file */
 
@@ -452,4 +452,4 @@ extern const char *g_commandNames[];
 #define SIGNATURE_SIZE 4
 extern const char g_signature[];
 
-#endif /* ! COMMANDS_H */
+#endif /* ! REMOTE_COMMANDS_H */


### PR DESCRIPTION
This was clashing with the new Commands.h file that is in Brunel. For now, the name will stay the same to avoid breaking clients of this header.