### PR TITLE
Update to v3 of upload-pages-artifact

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload Artifacts
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "html"
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
The old version seems to depend on v3 of upload-artifact, which is now deprecated and fails GitHub workflow runs.