### PR TITLE
Update Utils::CreateDirectory() to work with OS3

### DIFF
--- a/Utils.cpp
+++ b/Utils.cpp
@@ -560,6 +560,7 @@ TInt Utils::CreateDirectory(const char *a_pccDirectoryName)
 #ifdef __amigaos__
 
 	BPTR Lock;
+	LONG Error;
 
 	if ((Lock = CreateDir(a_pccDirectoryName)) != 0)
 	{
@@ -569,7 +570,11 @@ TInt Utils::CreateDirectory(const char *a_pccDirectoryName)
 	}
 	else
 	{
-		RetVal = (IoErr() == ERROR_OBJECT_EXISTS) ? KErrAlreadyExists : KErrNotFound;
+		Error = IoErr();
+
+		/* This is required for OS3 compatibility, as OS4 returns ERROR_OBJECT_EXISTS for directories that already */
+		/* exist, but OS3 returns ERROR_OBJECT_IN_USE */
+		RetVal = (Error == ERROR_OBJECT_EXISTS || Error == ERROR_OBJECT_IN_USE) ? KErrAlreadyExists : KErrNotFound;
 	}
 
 #elif defined(__unix__)


### PR DESCRIPTION
Take into account the fact that the OS3 version of CreateDir() returns a different error when a directory already exists to what the OS4 version returns.