### PR TITLE
Rename Application() to GetApplication()

### DIFF
--- a/Qt/QtLocalSocket.cpp
+++ b/Qt/QtLocalSocket.cpp
@@ -181,7 +181,7 @@ int RLocalSocket::OpenSocket(const char *a_pccName, RApplication *a_poApplicatio
 		{
 			/* Create an instance of a local server that can be used for listening for new connections */
 
-			if ((m_poLocalServer = new QLocalServer(a_poApplication->Application())) != NULL)
+			if ((m_poLocalServer = new QLocalServer(a_poApplication->GetApplication())) != NULL)
 			{
 				/* If the connection failed then it is likely that the program using the local socket did */
 				/* not shut down cleanly, so delete the local socket now so that a later attempt to */

--- a/StdApplication.h
+++ b/StdApplication.h
@@ -58,7 +58,7 @@ public:
 
 #ifdef QT_GUI_LIB
 
-	QApplication *Application()
+	QApplication *GetApplication()
 	{
 		return(m_poApplication);
 	}

--- a/StdDialog.cpp
+++ b/StdDialog.cpp
@@ -97,7 +97,7 @@ static INT_PTR CALLBACK DialogProc(HWND a_poWindow, UINT a_uiMessage, WPARAM a_o
 			/* is nothing to do with the above activation handling but is to do with crazy */
 			/* Windows message routing and is easier done separately */
 
-			Dialog->Application()->SetCurrentDialog((a_oWParam) ? a_poWindow : NULL);
+			Dialog->GetApplication()->SetCurrentDialog((a_oWParam) ? a_poWindow : NULL);
 
 			break;
 		}

--- a/StdWindow.cpp
+++ b/StdWindow.cpp
@@ -2585,7 +2585,7 @@ TInt CWindow::open(const char *a_pccTitle, const char *a_pccScreenName, TBool a_
 
 	RetVal = KErrNoMemory;
 
-	const QList<QScreen *> Screens = m_poApplication->Application()->screens();
+	const QList<QScreen *> Screens = m_poApplication->GetApplication()->screens();
 	QPoint MousePosition = QCursor::pos();
 	QScreen *TargetScreen = NULL;
 

--- a/StdWindow.h
+++ b/StdWindow.h
@@ -217,7 +217,7 @@ public:
 
 	TInt AddMenuItem(TStdMenuItemType a_eMenuItemType, const char *a_pccLabel, const char *a_pccHotKey, TInt a_iOrdinal, TInt a_iSubOrdinal, TInt a_iCommand);
 
-	RApplication *Application()
+	RApplication *GetApplication()
 	{
 		return(m_poApplication);
 	}


### PR DESCRIPTION
The latest Code HQ style guide states that we use the Get or get prefix for getters.