### PR TITLE
Don't pass entries array to RDir::read()

### DIFF
--- a/Dir.cpp
+++ b/Dir.cpp
@@ -1022,13 +1022,10 @@ void RDir::close()
 
 /**
  * Scans a directory for file and directory entries.
- * Scans a directory that has been prepared with RDir::open() and populates a list
- * with all of the entries found.  This list is then returned to the calling client
- * code.
+ * Scans a directory that has been prepared with RRemoteDir::open() and populates an internal list with all of
+ * the entries found.  This list can be then be accessed using getEntries().
  *
  * @date	Saturday 03-Nov-2007 5:38 pm
- * @param	a_rpoEntries	Reference to a ptr into which to place a ptr to the
- *							array of entries read by this function
  * @param	a_eSortOrder	Enumeration specifying the order in which to sort the files.
  *							EDirSortNone is used by default
  * @return	KErrNone if successful
@@ -1036,14 +1033,13 @@ void RDir::close()
  * @return	KErrGeneral if some other unspecified error occurred
  */
 
-TInt RDir::read(TEntryArray *&a_rpoEntries, enum TDirSortOrder a_eSortOrder)
+TInt RDir::read(enum TDirSortOrder a_eSortOrder)
 {
 	TInt RetVal;
 
 	/* Assume success */
 
 	RetVal = KErrNone;
-	a_rpoEntries = &m_entries;
 
 #ifdef __amigaos4__
 

--- a/Dir.h
+++ b/Dir.h
@@ -142,7 +142,12 @@ public:
 		m_entries.Purge();
 	}
 
-	virtual TInt read(TEntryArray *&a_entries, enum TDirSortOrder a_sortOrder = EDirSortNone) = 0;
+	TEntryArray *getEntries()
+	{
+		return &m_entries;
+	}
+
+	virtual TInt read(enum TDirSortOrder a_sortOrder = EDirSortNone) = 0;
 };
 
 /**
@@ -204,7 +209,7 @@ public:
 
 	void close();
 
-	TInt read(TEntryArray *&a_rpoEntries, enum TDirSortOrder a_eSortOrder = EDirSortNone);
+	TInt read(enum TDirSortOrder a_eSortOrder = EDirSortNone);
 };
 
 #endif /* ! DIR_H */

--- a/RemoteDir.cpp
+++ b/RemoteDir.cpp
@@ -121,22 +121,18 @@ int RRemoteDir::open(const char *a_pattern)
 
 /**
  * Scans a remote directory for file and directory entries.
- * Scans a directory that has been prepared with RRemoteDir::open() and populates a list with all of
- * the entries found.  This list is then returned to the calling client code.
+ * Scans a directory that has been prepared with RRemoteDir::open() and populates an internal list with all of
+ * the entries found.  This list can be then be accessed using getEntries().
  *
  * @date	Sunday 22-Jan-2023 10:42 am, Code HQ Tokyo Tsukuda
  * @param	a_entries		Reference to a ptr into which to place a ptr to the array of entries read
  *							by this function
- * @param	a_sortOrder		Enumeration specifying the order in which to sort the files.  EDirSortNone
- * 							is used by default
  * @return	KErrNone is always returned, as this method cannot fail
  */
 
-int RRemoteDir::read(TEntryArray *&a_entries, enum TDirSortOrder a_sortOrder)
+int RRemoteDir::read(enum TDirSortOrder a_sortOrder)
 {
 	(void) a_sortOrder;
-
-	a_entries = &m_entries;
 
 	return KErrNone;
 }

--- a/RemoteDir.h
+++ b/RemoteDir.h
@@ -26,7 +26,7 @@ public:
 
 	int open(const char *a_pattern);
 
-	int read(TEntryArray *&a_entries, enum TDirSortOrder a_sortOrder = EDirSortNone);
+	int read(enum TDirSortOrder a_sortOrder = EDirSortNone);
 
 	void setFactory(RRemoteFactory *a_remoteFactory, RSocket *a_socket)
 	{

--- a/Tests/T_Dir.cpp
+++ b/Tests/T_Dir.cpp
@@ -23,6 +23,7 @@ static RTest Test("T_Dir");		/* Class to use for testing and reporting results *
 static void TestScan(const char *a_pccPath, int a_iCount = 0, unsigned int a_iSize = 0)
 {
 	int Count, Index, FileIndex, Result;
+	TEntryArray *Entries;
 
 	/* Test opening using the path passed in */
 
@@ -31,10 +32,10 @@ static void TestScan(const char *a_pccPath, int a_iCount = 0, unsigned int a_iSi
 
 	/* Test that this can be read */
 
-	TEntryArray *Entries;
-	Result = g_oDir.read(Entries);
+	Result = g_oDir.read();
 	test(Result == KErrNone);
 
+	Entries = g_oDir.getEntries();
 	Count = Entries->Count();
 	FileIndex = 0;
 	Test.printf("Path \"%s\" count = %d\n", a_pccPath, Count);
@@ -162,10 +163,10 @@ int main()
 	Result = g_oDir.open("TimeFile.txt");
 	test(Result == KErrNone);
 
-	TEntryArray *Entries;
-	Result = g_oDir.read(Entries);
+	Result = g_oDir.read();
 	test(Result == KErrNone);
 
+	TEntryArray *Entries = g_oDir.getEntries();
 	test((*Entries)[0].iModified == Entry.iModified);
 	test((*Entries)[0].iAttributes == Entry.iAttributes);
 
@@ -179,7 +180,8 @@ int main()
 	test((Result == KErrNone) || (Result == KErrAlreadyExists));
 
 	test(g_oDir.open("EmptyDirectory") == KErrNone);
-	test(g_oDir.read(Entries) == KErrNone);
+	test(g_oDir.read() == KErrNone);
+	Entries = g_oDir.getEntries();
 	test(Entries->Count() == 0);
 
 	g_oDir.close();
@@ -188,7 +190,7 @@ int main()
 
 	Test.Next("Ensure calling RDir::read() on an unopened RDir fails gracefully");
 
-	test(g_oDir.read(Entries) == KErrGeneral);
+	test(g_oDir.read() == KErrGeneral);
 
 	/* The framework usually works identically on all platforms, but as there are */
 	/* subtle differences between different platforms when it comes to paths, this */
@@ -226,7 +228,8 @@ int main()
 	/* entry.  If not then it must failed as at least the test executable should be there */
 
 	test(g_oDir.open("PROGDIR:") == KErrNone);
-	test(g_oDir.read(Entries) == KErrNone);
+	test(g_oDir.read() == KErrNone);
+	Entries = g_oDir.getEntries();
 	test(Entries->Count() > 0);
 
 	/* Scan through the entries and find the test executable, which by definition *must* be present */

--- a/Tests/T_Time.cpp
+++ b/Tests/T_Time.cpp
@@ -47,10 +47,11 @@ int main()
 	Test.Next("Check file datestamp obtained from RDir");
 
 	RDir dir;
-	TEntryArray* dirEntries;
+	TEntryArray *dirEntries;
 
 	test(dir.open("T_Time.cpp") == KErrNone);
-	test(dir.read(dirEntries, EDirSortNone) == KErrNone);
+	test(dir.read(EDirSortNone) == KErrNone);
+	dirEntries = dir.getEntries();
 	test(dirEntries->Count() == 1);
 
 	TDateTime dirDateStamp = dirEntries->getHead()->iModified.DateTime();


### PR DESCRIPTION
This was causing confusion in terms of ownership, and could lead to surprises when RDir::close() was called and a list used by client code would suddenly as a result become empty. Instead of this list pointer being passed in, a pointer to the list of files can now be obtained by calling RDir::getFiles().