### PR TITLE
Update to v4 of deploy-pages

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -34,4 +34,4 @@ jobs:
           path: "html"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Uploading generated Doxygen documentation to GitHub has mysteriously stopped working, with no meaningful error, so let's try updating the version of the deploy-pages action.