### PR TITLE
Add KErrBreak error

### DIFF
--- a/StdFuncs.h
+++ b/StdFuncs.h
@@ -112,6 +112,7 @@ typedef signed long long TInt64;
 #define KErrNotOpen			-27
 #define KErrInvalidVersion	-28
 #define KErrTimeOut			-29
+#define KErrBreak			-30
 
 /* Useful macros for the WinMain() and main() functions, enabling them to be used */
 /* without #ifdefs in portable code */

--- a/StdSocket.cpp
+++ b/StdSocket.cpp
@@ -267,13 +267,14 @@ void RSocket::close()
  * @pre		The socket has been put in a listening state with listen()
  *
  * @date	Saturday 08-Apr-2023 8:22 am, Code HQ Tokyo Tsukuda
- * @return	KErrNone if successful, otherwise KErrGeneral
+ * @return	KErrNone if successful
+ * @return	KErrBreak if interrupted by ctrl+c signal
+ * @return 	KErrGeneral if any other error occurred
  */
 
 int RSocket::accept()
 {
-	int retVal = KErrGeneral;
-
+	int retVal;
 	socklen_t clientSize;
 	struct sockaddr_in client;
 
@@ -285,6 +286,10 @@ int RSocket::accept()
 	if (m_socket != INVALID_SOCKET)
 	{
 		retVal = KErrNone;
+	}
+	else
+	{
+		retVal = (errno == EINTR) ? KErrBreak : KErrGeneral;
 	}
 
 	return retVal;


### PR DESCRIPTION
Some StdFuncs library functions (starting with RSocket::accept()) will now return KErrBreak if they are interrupted by a ctrl+c signal, allowing better messages to be printed by client software when this event occurs.