### PR TITLE
Add ability to silently update gadget tree contents

### DIFF
--- a/StdGadgets.h
+++ b/StdGadgets.h
@@ -463,9 +463,11 @@ protected:
 
 	bool createNative();
 
-	int setContent(StdList<CTreeNode> &a_items, int a_contentID = 0);
+	int setContent(StdList<CTreeNode> &a_items, int a_contentID);
 
 public:
+
+	void activateContent(int a_contentID);
 
 	int getContentID()
 	{
@@ -473,8 +475,6 @@ public:
 	}
 
 	std::string getSelectedItem();
-
-	void setContent(int a_contentID);
 
 	void setTitle(const std::string &a_title);
 


### PR DESCRIPTION
When updating the contents of a tree gadget, this class will now check whether those contents are currently displayed on screen. If not, their contents will be silently updated, and no changes will be made to the displayed contents.