### PR TITLE
Add support for watching individual files

### DIFF
--- a/Amiga/AmiFileWatcher.h
+++ b/Amiga/AmiFileWatcher.h
@@ -22,12 +22,16 @@ class RAmiFileWatcher
 	MsgPort				*m_port;			/**< The message port used to receive for file change events */
 	NotifyRequest		*m_request;			/**< The request used to listen for file change events */
 	RDir				m_files;			/**< List of files in the directory being watched */
+	std::string			m_directoryName;	/**< Name of the directory being watched */
+	std::string			m_fileName;			/**< Name of the file being watched, if any */
 
 private:
 
 	void changed();
 
 	const TEntry *findEntry(const TEntryArray &a_entries, const char *a_name);
+
+	bool readFileList();
 
 public:
 
@@ -52,7 +56,7 @@ public:
 
 	void resumeWatching();
 
-	bool startWatching(const std::string &a_directoryName);
+	bool startWatching(const std::string &a_directoryName, const std::string *a_fileName);
 
 	void stopWatching();
 

--- a/Qt/QtFileWatcher.cpp
+++ b/Qt/QtFileWatcher.cpp
@@ -10,48 +10,54 @@
  * and to what files, and will call the internal platform independent callback.
  *
  * @date	Monday 08-Sep-2025 6:05 am, Code HQ Tokyo Tsukuda
- * @param	a_directoryName	The directory in which the change occurred
  */
 
-void RQtFileWatcher::changed(const QString &a_directoryName)
+void RQtFileWatcher::changed()
 {
-	QDir newDir(m_directoryName);
-
-	/* Detect files that were deleted. If the file is in the old list but not in the new list, it has been deleted */
-	auto it = m_files.begin();
-
-	while (it != m_files.end())
+	if (!m_fileName.isEmpty())
 	{
-		if (!newDir.exists(it.key()))
-		{
-			this->m_parentWatcher.changed(a_directoryName.toStdString(), it.key().toStdString(), EChangeDeleted);
-
-			/* Because we are modifying the files list while we are iterating through it, we have to carefully remove */
-			/* the current node while moving to the next one */
-			auto next = it;
-			++next;
-			m_files.remove(it.key());
-			it = next;
-		}
-		else
-		{
-			++it;
-		}
+		this->m_parentWatcher.changed(m_directoryName.toStdString(), m_fileName.toStdString(), EChangeModified);
 	}
-
-	/* Detect files that were added. If the file is in the new list but not in the old list, it is new */
-	for (auto &info : newDir.entryInfoList(QDir::Files))
+	else
 	{
-		if (!m_files.contains(info.fileName()))
+		QDir newDir(m_directoryName);
+
+		/* Detect files that were deleted. If the file is in the old list but not in the new list, it has been deleted */
+		auto it = m_files.begin();
+
+		while (it != m_files.end())
 		{
-			this->m_parentWatcher.changed(a_directoryName.toStdString(), info.fileName().toStdString(), EChangeAdded);
-			m_files[info.fileName()] = info.lastModified();
+			if (!newDir.exists(it.key()))
+			{
+				this->m_parentWatcher.changed(m_directoryName.toStdString(), it.key().toStdString(), EChangeDeleted);
+
+				/* Because we are modifying the files list while we are iterating through it, we have to carefully remove */
+				/* the current node while moving to the next one */
+				auto next = it;
+				++next;
+				m_files.remove(it.key());
+				it = next;
+			}
+			else
+			{
+				++it;
+			}
 		}
-		/* It's in both lists, so check its timestamp to see if it has been modified */
-		else if (m_files[info.fileName()] != info.lastModified())
+
+		/* Detect files that were added. If the file is in the new list but not in the old list, it is new */
+		for (auto &info : newDir.entryInfoList(QDir::Files))
 		{
-			// TODO: CAW - Attribute and time changes don't work on Qt
-			this->m_parentWatcher.changed(a_directoryName.toStdString(), info.fileName().toStdString(), EChangeModified);
+			if (!m_files.contains(info.fileName()))
+			{
+				this->m_parentWatcher.changed(m_directoryName.toStdString(), info.fileName().toStdString(), EChangeAdded);
+				m_files[info.fileName()] = info.lastModified();
+			}
+			/* It's in both lists, so check its timestamp to see if it has been modified */
+			else if (m_files[info.fileName()] != info.lastModified())
+			{
+				// TODO: CAW - Attribute and time changes don't work on Qt and Linux
+				this->m_parentWatcher.changed(m_directoryName.toStdString(), info.fileName().toStdString(), EChangeModified);
+			}
 		}
 	}
 }
@@ -65,7 +71,10 @@ void RQtFileWatcher::changed(const QString &a_directoryName)
 
 void RQtFileWatcher::pauseWatching()
 {
-	m_watcher.removePath(m_directoryName);
+	if (m_fileName.isEmpty())
+	{
+		m_watcher.removePath(m_directoryName);
+	}
 }
 
 /**
@@ -77,24 +86,53 @@ void RQtFileWatcher::pauseWatching()
 
 void RQtFileWatcher::resumeWatching()
 {
-	DEBUGCHECK(m_watcher.addPath(m_directoryName), "RQtFileWatcher::resumeWatching() => Could not restart file watching");
+	/* Only read the list of files if we are watching a directory, rather than an individual file */
+	if (m_fileName.isEmpty())
+	{
+		QDir dir(m_directoryName);
+
+		/* Purge the old list of files in the watched directory */
+		m_files.clear();
+
+		/* Refresh the contents of the cached file list, in case something changed while we were paused */
+		for (auto &info : dir.entryInfoList(QDir::Files))
+		{
+			m_files[info.fileName()] = info.lastModified();
+		}
+
+		DEBUGCHECK(m_watcher.addPath(m_directoryName), "RQtFileWatcher::resumeWatching() => Could not restart file watching");
+	}
 }
 
 /**
  * Starts file watching.
  * Adds the given directory to the list of directories being watched and saves a list of files in that directory,
  * which can be used to determine what files have been changed when a directory change signal is received from Qt.
+ * Alternatively, will set up single file watch if the optional a_fileName parameter is passed in.
  *
  * @date	Monday 11-Aug-2025 1:20 pm, Sarutahiko Coffee Marunouchi
  * @param	a_directoryName	The name of the directory to be watched
+ * @param	a_fileName		Optional name of a specific file to watch
  * @return	True if the watcher was started successfully, otherwise false
  */
 
-bool RQtFileWatcher::startWatching(const std::string &a_directoryName)
+bool RQtFileWatcher::startWatching(const std::string &a_directoryName, const std::string *a_fileName)
 {
 	m_directoryName = QString::fromStdString(a_directoryName);
 
-	if (m_watcher.addPath(m_directoryName))
+	if (a_fileName != nullptr)
+	{
+		m_fileName = QDir(m_directoryName).filePath(QString::fromStdString(*a_fileName));
+		m_watcher.addPath(m_fileName);
+
+		/* Connect to the fileChanged signal so that we receive a callback when it is emitted */
+		QObject::connect(&m_watcher, &QFileSystemWatcher::fileChanged, [this](const QString &) {
+			this->changed();
+		});
+
+		return true;
+	}
+	else if (m_watcher.addPath(m_directoryName))
 	{
 		/* The signal only indicates that something has changed, not what has changed. So we need to make a snapshot */
 		/* of the contents of the directory under observation for later reference when we receive a signal */
@@ -106,8 +144,8 @@ bool RQtFileWatcher::startWatching(const std::string &a_directoryName)
 		}
 
 		/* Connect to the directoryChanged signal so that we receive a callback when it is emitted */
-		QObject::connect(&m_watcher, &QFileSystemWatcher::directoryChanged, [this](const QString &a_directoryName) {
-			this->changed(a_directoryName);
+		QObject::connect(&m_watcher, &QFileSystemWatcher::directoryChanged, [this](const QString &) {
+			this->changed();
 		});
 
 		return true;
@@ -127,5 +165,17 @@ bool RQtFileWatcher::startWatching(const std::string &a_directoryName)
 void RQtFileWatcher::stopWatching()
 {
 	QObject::disconnect(m_connection);
-	m_watcher.removePath(m_directoryName);
+
+	if (!m_directoryName.isEmpty())
+	{
+		m_watcher.removePath(m_directoryName);
+	}
+
+	if (!m_fileName.isEmpty())
+	{
+		m_watcher.removePath(m_fileName);
+	}
+
+	m_directoryName.clear();
+	m_fileName.clear();
 }

--- a/Qt/QtFileWatcher.h
+++ b/Qt/QtFileWatcher.h
@@ -28,10 +28,11 @@ private:
 	QMap<QString, QDateTime>	m_files;			/**< List of files in the directory being watched */
 	QMetaObject::Connection		m_connection;		/**< Connection set up by call to QObject::connect() */
 	QString						m_directoryName;	/**< Name of the directory being watched */
+	QString						m_fileName;			/**< Name of the file being watched, if any */
 
 private:
 
-	void changed(const QString &a_directoryName);
+	void changed();
 
 public:
 
@@ -41,7 +42,7 @@ public:
 
 	void resumeWatching();
 
-	bool startWatching(const std::string &a_directoryName);
+	bool startWatching(const std::string &a_directoryName, const std::string *a_fileName);
 
 	void stopWatching();
 };

--- a/StdFileWatcher.h
+++ b/StdFileWatcher.h
@@ -56,7 +56,6 @@ class RStdFileWatcher
 
 	TState				m_state;			/**< Current state of the file watcher */
 	Callback			m_callback;			/**< Client callback to invoke when a change is detected */
-	std::string			m_directoryName;	/**< Name of the directory being watched */
 
 #ifdef __amigaos__
 
@@ -71,6 +70,8 @@ class RStdFileWatcher
 	BYTE				m_buffer[8192];		/**< Buffer for file change notification information */
 	HANDLE				m_changeHandle = INVALID_HANDLE_VALUE;	/**< Handle to the directory being watched */
 	OVERLAPPED			m_overlapped;		/**< OVERLAPPED structure passed to ReadDirectoryChangesW() */
+	std::string			m_directoryName;	/**< Name of the directory being watched */
+	std::string			m_fileName;			/**< Name of the file being watched */
 
 #endif /* defined(WIN32) */
 
@@ -107,7 +108,7 @@ public:
 
 	void resumeWatching();
 
-	bool startWatching(const std::string &a_directoryName, Callback a_callback);
+	bool startWatching(const std::string &a_directoryName, const std::string *a_fileName, Callback a_callback);
 
 	void stopWatching();
 


### PR DESCRIPTION
Watching an entire directory for changes to a file is not guaranteed to work on all operating systems. Some operating systems only notify that a file is added or deleted, not changed. This change adds support for watching an individual file (such as a configuration file) to be sure that changes to it are picked up.