### PR TITLE
Properly shut down file watcher on Windows

### DIFF
--- a/FileWatcher.cpp
+++ b/FileWatcher.cpp
@@ -39,15 +39,23 @@ void RFileWatcher::changed(const std::string &a_directoryName, const std::string
 
 void CALLBACK RFileWatcher::completionRoutine(DWORD a_errorCode, DWORD a_bytesTransfered, LPOVERLAPPED a_overlapped)
 {
+	SOverlapped *overlapped = reinterpret_cast<SOverlapped *>(a_overlapped);
+	RFileWatcher *self = overlapped->m_fileWatcher;
+
+	if (a_errorCode == ERROR_OPERATION_ABORTED)
+	{
+		/* Signal stopWatching() that we are truly done, as it will be waiting for any pending notifications to */
+		/* complete before it returns. */
+		SetEvent(self->m_stopEvent);
+	}
 	/* The Windows file watching API does not handle the situation of the buffer being too small very well. If it is */
 	/* too small, notifications will be lost and there is no way to recover. So just check that some data was actually */
 	/* received and handle whatever we get */
-	if (a_errorCode == ERROR_SUCCESS && a_bytesTransfered > 0)
+	else if (a_errorCode == ERROR_SUCCESS && a_bytesTransfered > 0)
 	{
 		char fileName[MAX_PATH];
 		int length;
 		DWORD offset = 0;
-		RFileWatcher *self = reinterpret_cast<RFileWatcher *>(a_overlapped->hEvent);
 		FILE_NOTIFY_INFORMATION *info = reinterpret_cast<FILE_NOTIFY_INFORMATION *>(self->m_buffer);
 
 		/* Iterate through the notifications that were received, check their type and call the generic watcher callback */
@@ -236,14 +244,30 @@ void RFileWatcher::stopWatching()
 
 		m_watcher.stopWatching();
 
-#elif defined(QT_GUI_LIB)
+#elif defined(WIN32)
 
-		m_watcher.stopWatching();
-
-#elif !defined(__unix__)
-
+		/* If a watch has been queued with ReadDirectoryChangesW(), cancel it and wait for the callback to complete */
+		/* before returning. This is necessary to prevent Windows from accessing any resources associated with this */
+		/* callback after stopWatching() has returned */
 		if (m_changeHandle != INVALID_HANDLE_VALUE)
 		{
+			BOOL bCancelled = CancelIoEx(m_changeHandle, nullptr);
+
+			if (bCancelled || GetLastError() == ERROR_NOT_FOUND)
+			{
+				m_stopEvent = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+
+				if (m_stopEvent != nullptr)
+				{
+					/* Enter an alertable wait until the completion routine fires and signals m_stopEvent */
+					while (WaitForSingleObjectEx(m_stopEvent, INFINITE, TRUE) != WAIT_OBJECT_0) { }
+
+					CloseHandle(m_stopEvent);
+				}
+
+				m_stopEvent = INVALID_HANDLE_VALUE;
+			}
+
 			CloseHandle(m_changeHandle);
 			m_changeHandle = INVALID_HANDLE_VALUE;
 		}
@@ -251,7 +275,7 @@ void RFileWatcher::stopWatching()
 		m_directoryName.clear();
 		m_fileName.clear();
 
-#endif /* ! __unix__ */
+#endif /* WIN32 */
 
 	}
 
@@ -274,8 +298,8 @@ bool RFileWatcher::watchDirectory()
 {
 	ZeroMemory(&m_overlapped, sizeof(m_overlapped));
 
-	/* Stash "this" in hEvent so we can retrieve it inside the completion routine */
-	m_overlapped.hEvent = this;
+	/* Stash "this" in the overlapped structure so we can retrieve it inside the completion routine */
+	m_overlapped.m_fileWatcher = this;
 
 	/* We want to watch for adds, deletes, renames and modifications */
 	return ReadDirectoryChangesW(m_changeHandle, m_buffer, sizeof(m_buffer), FALSE,

--- a/FileWatcher.h
+++ b/FileWatcher.h
@@ -80,6 +80,19 @@ public:
 class RFileWatcher : public RFileWatcherObject
 {
 
+#if defined(WIN32) && !defined(QT_GUI_LIB)
+
+	/**
+	 * A structure for use when an OVERLAPPED structure is required, and when we want to save state associated with
+	 * that structure.
+	 */
+	struct SOverlapped : public OVERLAPPED
+	{
+		RFileWatcher	*m_fileWatcher;		/**< Pointer to the associated RFileWatcher object */
+	};
+
+#endif /* defined(WIN32) && !defined(QT_GUI_LIB) */
+
 #ifdef __amigaos__
 
 	RAmiFileWatcher		m_watcher;			/**< Amiga-specific helper class for file system monitoring */
@@ -92,7 +105,8 @@ class RFileWatcher : public RFileWatcherObject
 
 	BYTE				m_buffer[8192];		/**< Buffer for file change notification information */
 	HANDLE				m_changeHandle = INVALID_HANDLE_VALUE;	/**< Handle to the directory being watched */
-	OVERLAPPED			m_overlapped;		/**< OVERLAPPED structure passed to ReadDirectoryChangesW() */
+	HANDLE				m_stopEvent = INVALID_HANDLE_VALUE;		/**< Event used by the completion routine to indicate shutdown */
+	SOverlapped			m_overlapped;		/**< OVERLAPPED structure passed to ReadDirectoryChangesW() */
 	std::string			m_directoryName;	/**< Name of the directory being watched */
 	std::string			m_fileName;			/**< Name of the file being watched */
 


### PR DESCRIPTION
On Windows, it is not sufficient to simply close the handle associated with an outstanding Overlapped I/O request, as the completion routine can still be called afterwards, possibly resulting in it accessing memory that has been freed. We have to have a controlled shutdown and allow the completion routine to signal that it has been called.