### PR TITLE
Add support for passing arguments to launchCommand()

### DIFF
--- a/Qt/QtExecuter.cpp
+++ b/Qt/QtExecuter.cpp
@@ -11,12 +11,13 @@
  *
  * @date	Friday 27-Mar-2026 6:13 am, Code HQ Tokyo Tsukuda
  * @param	a_commandName	The name of the command to be launched
+ * @param	a_arguments		The arguments to be passed to the command, or nullptr if no arguments
  * @return	KErrNone if the command was launched successfully
  * @return	KErrNotFound if the command could not be found
  * @return	KErrInUse if a command is already being executed
  */
 
-int RQtExecuter::launchCommand(const char *a_commandName)
+int RQtExecuter::launchCommand(const char *a_commandName, const char *a_arguments)
 {
 	/* Only launch the command if a command is not already running */
 	if (m_process != nullptr)
@@ -31,8 +32,17 @@ int RQtExecuter::launchCommand(const char *a_commandName)
 	connect(m_process, &QProcess::readyReadStandardError, this, &RQtExecuter::onReadyRead);
 	connect(m_process, &QProcess::finished, this, &RQtExecuter::onFinished);
 
+	/* Append any arguments passed in onto the command line */
+	QStringList arguments;
+
+	if (a_arguments != nullptr)
+	{
+		QString argsStr(a_arguments);
+		arguments = argsStr.split(' ', Qt::SkipEmptyParts);
+	}
+
 	/* Start the process asynchronously and wait for it to actually start */
-	m_process->start(a_commandName);
+	m_process->start(a_commandName, arguments);
 
 	if (m_process->waitForStarted())
 	{

--- a/Qt/QtExecuter.h
+++ b/Qt/QtExecuter.h
@@ -32,7 +32,7 @@ public:
 		return (m_process != nullptr);
 	}
 
-	int launchCommand(const char *a_commandName);
+	int launchCommand(const char *a_commandName, const char *a_arguments);
 };
 
 #endif /* ! QTEXECUTER_H */

--- a/StdExecuter.cpp
+++ b/StdExecuter.cpp
@@ -248,7 +248,7 @@ void RStdExecuter::readComplete(const char *a_buffer, int a_size, const TResult 
 
 /**
  * Process a block of data read by an overlapped ReadFileEx() call.
- * This method is called by the Windows-specific helper class when data becomes available asynchronously, or when the 
+ * This method is called by the Windows-specific helper class when data becomes available asynchronously, or when the
  * end of the file has been reached. It will simply pass the data and result to the client's callback method.
  *
  * @date	Saturday 28-Mar-2026 7:36 am, Code HQ Tokyo Tsukuda
@@ -313,6 +313,7 @@ VOID CALLBACK RStdExecuter::readCompletionRoutine(DWORD a_errorCode, DWORD a_byt
  *
  * @date	Monday 15-Feb-2021 7:19 am, Code HQ Bergmannstrasse
  * @param	a_commandName	The name of the command to be launched
+ * @param	a_arguments		The arguments to be passed to the command, or nullptr if no arguments
  * @param	a_stackSize		The stack size to be used on the target machine (Amiga OS only)
  * @param	a_callback		The callback to be called when data is available
  * @return	KErrNone if the command was launched successfully
@@ -322,8 +323,9 @@ VOID CALLBACK RStdExecuter::readCompletionRoutine(DWORD a_errorCode, DWORD a_byt
  * @return	KErrGeneral if any other error occurred
  */
 
-int RStdExecuter::launchCommand(const char *a_commandName, int a_stackSize, Callback a_callback)
+int RStdExecuter::launchCommand(const char *a_commandName, const char *a_arguments, int a_stackSize, Callback a_callback)
 {
+	ASSERTM((a_commandName != nullptr), "Command name must not be NULL");
 
 #ifdef __amigaos__
 
@@ -354,7 +356,16 @@ int RStdExecuter::launchCommand(const char *a_commandName, int a_stackSize, Call
 		m_exitData.m_sigBit = AllocSignal(-1);
 		m_exitData.m_parentTask = FindTask(nullptr);
 
-		int result = SystemTags(a_commandName, SYS_Input, (ULONG) m_stdInRead, SYS_Output, (ULONG) m_stdOutWrite,
+		/* Append any arguments passed in onto the command line */
+		std::string commandLine(a_commandName);
+
+		if (a_arguments != nullptr)
+		{
+			commandLine += " ";
+			commandLine += a_arguments;
+		}
+
+		int result = SystemTags(commandLine.c_str(), SYS_Input, (ULONG) m_stdInRead, SYS_Output, (ULONG) m_stdOutWrite,
 			NP_ExitCode, (ULONG) ExitFunction, NP_ExitData, (ULONG) &m_exitData, SYS_Asynch, TRUE, NP_StackSize, stackSize,
 			TAG_DONE);
 
@@ -393,7 +404,7 @@ int RStdExecuter::launchCommand(const char *a_commandName, int a_stackSize, Call
 
 	m_callback = a_callback;
 
-	int retVal = m_executer.launchCommand(a_commandName);
+	int retVal = m_executer.launchCommand(a_commandName, a_arguments);
 
 #elif defined(WIN32)
 
@@ -433,7 +444,7 @@ int RStdExecuter::launchCommand(const char *a_commandName, int a_stackSize, Call
 
 						/* Create the child process. This will read from and write to the pipes we have created, */
 						/* and upon exit will close its end of the pipes, so that we can detect that it has exited */
-						if ((retVal = createChildProcess(a_commandName, m_childProcess)) == KErrNone)
+						if ((retVal = createChildProcess(a_commandName, a_arguments, m_childProcess)) == KErrNone)
 						{
 							m_buffer = new char[STDOUT_BUFFER_SIZE];
 
@@ -475,11 +486,12 @@ int RStdExecuter::launchCommand(const char *a_commandName, int a_stackSize, Call
  *
  * @date	Monday 15-Feb-2021 7:19 am, Code HQ Bergmannstrasse
  * @param	a_commandName	The name of the command to be launched
+ * @param	a_arguments		The arguments to be passed to the command, or nullptr if no arguments
  * @return	KErrNone if the command was launched successfully
  * @return	KErrNotFound if the command executable could not be found
  */
 
-int RStdExecuter::createChildProcess(const char *a_commandName, HANDLE &a_childProcess)
+int RStdExecuter::createChildProcess(const char *a_commandName, const char *a_arguments, HANDLE &a_childProcess)
 {
 	int retVal;
 	PROCESS_INFORMATION processInfo;
@@ -495,10 +507,17 @@ int RStdExecuter::createChildProcess(const char *a_commandName, HANDLE &a_childP
 	startupInfo.hStdInput = m_stdInRead;
 	startupInfo.dwFlags |= STARTF_USESTDHANDLES;
 
-	std::string commandName(a_commandName);
+	/* Append any arguments passed in onto the command line */
+	std::string commandLine(a_commandName);
+
+	if (a_arguments != nullptr)
+	{
+		commandLine += " ";
+		commandLine += a_arguments;
+	}
 
 	/* Create the requested child process */
-	if (CreateProcess(NULL, (char *) commandName.c_str(), NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &startupInfo, &processInfo))
+	if (CreateProcess(NULL, (char *) commandLine.c_str(), NULL, NULL, TRUE, CREATE_NO_WINDOW, NULL, NULL, &startupInfo, &processInfo))
 	{
 		retVal = KErrNone;
 		a_childProcess = processInfo.hProcess;

--- a/StdExecuter.h
+++ b/StdExecuter.h
@@ -127,7 +127,7 @@ private:
 
 #if defined(WIN32) && !defined(QT_GUI_LIB)
 
-	int createChildProcess(const char *a_commandName, HANDLE &a_childProcess);
+	int createChildProcess(const char *a_commandName, const char *a_arguments, HANDLE &a_childProcess);
 
 	static void CALLBACK readCompletionRoutine(DWORD a_errorCode, DWORD a_bytesTransferred, LPOVERLAPPED a_overlapped);
 
@@ -158,7 +158,7 @@ public:
 
 	}
 
-	int launchCommand(const char *a_commandName, int a_stackSize, Callback a_callback);
+	int launchCommand(const char *a_commandName, const char *a_arguments, int a_stackSize, Callback a_callback);
 
 #ifdef __amigaos__
 

--- a/StdGadgets.h
+++ b/StdGadgets.h
@@ -29,13 +29,17 @@ class QLabel;
 class QWidget;
 struct ColumnInfo;
 
-#ifdef __amigaos__
-
 /* A typedef to make usage of the map of item lists easier */
+
+#ifdef __amigaos__
 
 typedef std::map<int, List> ItemsMap;
 
-#endif /* __amigaos__ */
+#elif defined(QT_GUI_LIB)
+
+typedef std::map<int, QList<QTreeWidgetItem *>> ItemsMap;
+
+#endif /* QT_GUI_LIB */
 
 /* Types of gadgets that can be created */
 
@@ -470,8 +474,8 @@ class CStdGadgetTree : public CStdGadget
 
 #elif defined(QT_GUI_LIB)
 
-	CQtGadgetTree							m_tree;		/**< Helper class for listening for signals */
-	std::map<int, QList<QTreeWidgetItem *>>	m_itemsMap;	/**< Map of the lists of items that can be displayed by the tree */
+	CQtGadgetTree	m_tree;				/**< Helper class for listening for signals */
+	ItemsMap		m_itemsMap;			/**< Map of the lists of items that can be displayed by the tree */
 
 #endif /* QT_GUI_LIB */
 


### PR DESCRIPTION
Passing one or more arguments is required to support the Brunel build system, which may pass in arguments such as DEBUG=1 when launching build systems such as make.