### PR TITLE
Delete QProcess object on launch failure

### DIFF
--- a/Qt/QtExecuter.cpp
+++ b/Qt/QtExecuter.cpp
@@ -50,6 +50,10 @@ int RQtExecuter::launchCommand(const char *a_commandName, const char *a_argument
 	}
 	else
 	{
+		/* Delete the QProcess object, to indicate that the launch failed */
+		delete m_process;
+		m_process = nullptr;
+
 		return KErrNotFound;
 	}
 }


### PR DESCRIPTION
The instance of QProcess being used for launching binaries on Qt was not being deleted if the binary could not be found, meaning that the next time RQtExecuter::launchCommand() was found, the class thought it was already in use and the launch failed.