### PR TITLE
Add support for text themes

### DIFF
--- a/Qt/QtFileWatcher.h
+++ b/Qt/QtFileWatcher.h
@@ -30,7 +30,7 @@ private:
 	QString						m_fileName;			/**< Name of the file being watched, if any */
 	RFileWatcher				&m_parentWatcher;	/**< Reference to framework watcher that uses this Qt watcher */
 
-private:
+private slots:
 
 	void changed();
 

--- a/Qt/QtWindow.cpp
+++ b/Qt/QtWindow.cpp
@@ -5,6 +5,7 @@
 #include "QtWindow.h"
 #include <QLocale>
 #include <QtGui/QKeyEvent>
+#include <QtGui/QStyleHints>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QMenuBar>
 
@@ -37,10 +38,8 @@ static const SKeyMapping g_aoKeyMap[] =
  */
 
 CQtWindow::CQtWindow(CWindow *a_poWindow, QPoint &a_roPosition, QSize &a_roSize)
+	: m_poWindow(a_poWindow), m_oSize(a_roSize), m_oCurrentScheme(Qt::ColorScheme::Unknown)
 {
-	m_poWindow = a_poWindow;
-	m_oSize = a_roSize;
-
 	move(a_roPosition);
 	resize(a_roSize);
 
@@ -247,6 +246,36 @@ void CQtWindow::HandlePointerEvent(QMouseEvent *a_poMouseEvent)
 	if ((X >= 0) && (Y >= 0))
 	{
 		m_poWindow->HandlePointerEvent(X, Y, MouseEvent);
+	}
+}
+
+/**
+ * Qt helper function to capture OS colour theme change events.
+ * This function is called whenever the OS's colour theme changes, for example from a dark to a light theme.
+ *
+ * @date	Friday 12-Jun-2026 6:42 am, Code HQ Tokyo Tsukuda
+ * @param	a_poEvent		Pointer to structure containing information for handling the event
+ */
+
+void CQtWindow::changeEvent(QEvent *a_event)
+{
+	QMainWindow::changeEvent(a_event);
+
+	/* Check whether this is a layout engine change or a palette modification */
+	if (a_event->type() == QEvent::ThemeChange || a_event->type() == QEvent::PaletteChange)
+	{
+		Qt::ColorScheme activeScheme = QGuiApplication::styleHints()->colorScheme();
+
+		/* Some operating systems will send multiple change events, so we only need to handle the first one. */
+		/* We keep a track of the current scheme so we can ignore duplicate events */
+		if (m_oCurrentScheme == activeScheme)
+		{
+			return;
+		}
+
+		/* The theme has actually changed, so save it for later and call the client callback */
+		m_oCurrentScheme = activeScheme;
+		m_poWindow->ThemeChanged();
 	}
 }
 

--- a/Qt/QtWindow.h
+++ b/Qt/QtWindow.h
@@ -20,9 +20,10 @@ class CQtWindow : public QMainWindow
 
 private:
 
-	bool		m_bClosing;		/**< true if in the window is in the process of being closed */
-	CWindow		*m_poWindow;	/**< Ptr to framework window represented by this Qt window */
-	QSize		m_oSize;		/**< Preferred size of the non maximised window */
+	bool		m_bClosing;				/**< true if in the window is in the process of being closed */
+	CWindow		*m_poWindow;			/**< Ptr to framework window represented by this Qt window */
+	QSize		m_oSize;				/**< Preferred size of the non maximised window */
+	Qt::ColorScheme	m_oCurrentScheme;	/**< Currently set OS colour theme */
 
 private:
 
@@ -33,6 +34,8 @@ private:
 protected:
 
 	/* From QMainWindow */
+
+	void changeEvent(QEvent *a_event) override;
 
 	void closeEvent(QCloseEvent *a_poCloseEvent) override;
 

--- a/StdApplication.cpp
+++ b/StdApplication.cpp
@@ -620,6 +620,15 @@ TInt RApplication::Main()
 
 #elif defined(QT_GUI_LIB)
 
+#ifdef WIN32
+
+	/* For Windows, we have to set the Style to "Fusion", or the default "Windowsvista" will have trouble switching */
+	/* between light and dark OS colour themes */
+
+	m_poApplication->setStyle("Fusion");
+
+#endif /* WIN32 */
+
 	m_poApplication->exec();
 
 #elif defined(WIN32)

--- a/StdExecuter.cpp
+++ b/StdExecuter.cpp
@@ -467,6 +467,7 @@ int RStdExecuter::launchCommand(const char *a_commandName, const char *a_argumen
 #else /* ! WIN32 */
 
 	(void) a_commandName;
+	(void) a_arguments;
 	(void) a_stackSize;
 	(void) a_callback;
 

--- a/StdFont.cpp
+++ b/StdFont.cpp
@@ -19,10 +19,10 @@
 
 #endif /* QT_GUI_LIB */
 
-/* Colours that can be printed by RFont::DrawColouredText().  This must match */
-/* STDFONT_NUM_COLOURS in StdFont.h */
+/* Colours that can be printed by RFont::DrawColouredText().  This must match STDFONT_NUM_COLOURS in StdFont.h. */
+/* These colours can be changed and, when changed, apply to all instances of the RFont class */
 
-static const COLORREF g_acoColours[] = { RGB(0, 0, 0), RGB(163, 21, 21), RGB(0, 128, 0), RGB(0, 0, 255) };
+static COLORREF g_acoColours[] = { RGB(0, 0, 0), RGB(163, 21, 21), RGB(0, 128, 0), RGB(0, 0, 255) };
 
 #if defined(WIN32) && !defined(QT_GUI_LIB)
 
@@ -517,6 +517,11 @@ TInt RFont::Begin()
 	if (RetVal == KErrNone)
 	{
 		m_bBeginCalled = ETrue;
+
+		/* Set the text and background colours to their default as these are held by the operating system and may have */
+		/* changed during a previous use of the RFont class */
+
+		SetHighlight(EFalse);
 	}
 
 #endif /* _DEBUG */
@@ -1272,6 +1277,25 @@ int RFont::PixelToOffset(const char *a_pccText, int a_iPixelX, int a_iLength)
 #endif /* ! defined(QT_GUI_LIB) && defined(__APPLE__) */
 
 	return(RetVal);
+}
+
+/**
+ * Set the colours for all instances of the RFont class.
+ * Sets the colours to be used for all instances of the RFont class. The colours are specified as an array of COLORREF
+ * values, and the number of colours passed in must be equal to STDFONT_NUM_COLOURS. There are no check that this is
+ * actually the case. Each colour in the array passed in replaces the corresponding colour in the global array, and
+ * they are still indexed by the usual STDFONT_BLACK etc. indices.
+ *
+ * @date	Wednesday 27-May-2026 1:54 pm, on board Jetstar flight GK335 from Tokyo to Naha
+ * @param	a_colours		Array of colours to be used for all instances of the RFont class
+ */
+
+void RFont::setColours(const COLORREF *a_colours)
+{
+	for (int index = 0; index < STDFONT_NUM_COLOURS; ++index)
+	{
+		g_acoColours[index] = a_colours[index];
+	}
 }
 
 /* Written: Saturday 21-Aug-2010 8:27 pm */

--- a/StdFont.h
+++ b/StdFont.h
@@ -121,6 +121,8 @@ public:
 
 	int PixelToOffset(const char *a_pccText, int a_iPixelX, int a_iLength);
 
+	void setColours(const COLORREF *a_colours);
+
 	void SetHighlight(TBool a_bHighlight);
 
 	void SetDrawingRect(TInt a_iXOffset, TInt a_iYOffset, TInt a_iWidth, TInt a_iHeight);

--- a/StdFuncs.pro
+++ b/StdFuncs.pro
@@ -3,7 +3,7 @@ TARGET = StdFuncs
 TEMPLATE = lib
 CONFIG += debug_and_release staticlib warn_on
 CONFIG -= rtti
-QT += core5compat
+QT += core5compat widgets
 
 # Some tricks to get rid of most of the contents of the largish .eh_frame section
 gcc:QMAKE_CXXFLAGS += -fno-asynchronous-unwind-tables
@@ -31,7 +31,7 @@ SOURCES += Args.cpp Dir.cpp File.cpp FileUtils.cpp FileWatcher.cpp Lex.cpp MungW
 	StdApplication.cpp StdCharConverter.cpp StdClipboard.cpp StdConfigFile.cpp StdCRC.cpp StdDialog.cpp StdExecuter.cpp \
 	StdFileRequester.cpp StdFont.cpp StdGadgets.cpp StdGadgetLayout.cpp StdGadgetSlider.cpp StdGadgetStatusBar.cpp \
 	StdGadgetTabPane.cpp StdGadgetTree.cpp StdImage.cpp StdPool.cpp StdRendezvous.cpp StdSocket.cpp StdStringList.cpp \
-	StdTextFile.cpp StdTime.cpp StdWildcard.cpp StdWindow.cpp Test.cpp Utils.cpp
+	StdTextFile.cpp StdTheme.cpp StdTime.cpp StdWildcard.cpp StdWindow.cpp Test.cpp Utils.cpp
 
 SOURCES += Qt/QtAction.cpp Qt/QtExecuter.cpp Qt/QtFileWatcher.cpp Qt/QtGadgetSlider.cpp Qt/QtGadgetTree.cpp \
 	Qt/QtLocalSocket.cpp Qt/QtWindow.cpp
@@ -39,8 +39,8 @@ SOURCES += Qt/QtAction.cpp Qt/QtExecuter.cpp Qt/QtFileWatcher.cpp Qt/QtGadgetSli
 HEADERS += Args.h Dir.h File.h FileUtils.h FileWatcher.h Lex.h MungWall.h RemoteDir.h RemoteFactory.h RemoteFile.h \
 	RemoteFileUtils.h RemoteFileWatcher.h StdApplication.h StdCharConverter.h StdClipboard.h StdConfigFile.h StdDialog.h \
 	StdExecuter.h StdFileRequester.h StdFont.h StdFuncs.h StdGadgets.h StdGadgetTabPane.h StdImage.h StdList.h StdPool.h \
-	StdReaction.h StdRendezvous.h StdSocket.h StdStringList.h StdTextFile.h StdTime.h StdWildcard.h StdWindow.h Test.h \
-	Utils.h
+	StdReaction.h StdRendezvous.h StdSocket.h StdStringList.h StdTextFile.h StdTheme.h StdTime.h StdWildcard.h StdWindow.h \
+	Test.h Utils.h
 
 HEADERS += Qt/QtAction.h Qt/QtExecuter.h Qt/QtFileWatcher.h Qt/QtGadgetSlider.h Qt/QtGadgetTree.h Qt/QtLocalSocket.h \
 	Qt/QtWindow.h

--- a/StdFuncs.vcxproj
+++ b/StdFuncs.vcxproj
@@ -235,6 +235,7 @@
     <ClCompile Include="StdSocket.cpp" />
     <ClCompile Include="StdStringList.cpp" />
     <ClCompile Include="StdTextFile.cpp" />
+    <ClCompile Include="StdTheme.cpp" />
     <ClCompile Include="StdTime.cpp" />
     <ClCompile Include="StdWildcard.cpp" />
     <ClCompile Include="StdWindow.cpp" />
@@ -274,6 +275,7 @@
     <ClInclude Include="StdSocket.h" />
     <ClInclude Include="StdStringList.h" />
     <ClInclude Include="StdTextFile.h" />
+    <ClInclude Include="StdTheme.h" />
     <ClInclude Include="StdTime.h" />
     <ClInclude Include="StdWildcard.h" />
     <ClInclude Include="StdWindow.h" />

--- a/StdGadgetStatusBar.cpp
+++ b/StdGadgetStatusBar.cpp
@@ -3,6 +3,7 @@
 #include <string.h>
 #include "StdGadgets.h"
 #include "StdReaction.h"
+#include "StdTheme.h"
 #include "StdWindow.h"
 
 #ifdef __amigaos__
@@ -156,16 +157,31 @@ TInt CStdGadgetStatusBar::Construct(TInt a_iNumParts, TInt *a_piPartsOffsets)
 		/* Create a style sheet and assign it to the status bar, to ensure that it looks */
 		/* half decent and is actually usable.  Without this it is almost invisible! */
 
-		QString styleSheet = "\
-			QStatusBar {\
-				background : #f2f1f0;\
-			}\
-			\
-			QStatusBar::item {\
-				border : 1px solid #c9c6c3;\
-				border-radius: 3px;\
-			}\
-		";
+		QString styleSheet;
+		RStdTheme stdTheme;
+
+		// TODO: CAW - This also needs to be done for other borders such as the file list, should use values
+		//             from Brunel.ini and should be performed on theme change
+		if (stdTheme.lightTheme())
+		{
+			styleSheet = "\
+				QStatusBar {\
+					background : #f2f1f0;\
+				}\
+				\
+				QStatusBar::item {\
+					border : 1px solid #c9c6c3;\
+					border-radius: 3px;\
+				}";
+		}
+		else
+		{
+			styleSheet = "\
+				QStatusBar::item {\
+					border : 1px solid;\
+					border-radius: 3px;\
+			}";
+		}
 
 		StatusBar->setStyleSheet(styleSheet);
 

--- a/StdTheme.cpp
+++ b/StdTheme.cpp
@@ -1,0 +1,141 @@
+
+#include "StdFuncs.h"
+#include "Lex.h"
+#include "StdTheme.h"
+#include <string.h>
+
+#ifdef __amigaos__
+
+#include <proto/graphics.h>
+
+#elif defined(QT_GUI_LIB)
+
+#include <QStyleHints>
+#include <QApplication>
+
+#endif /* QT_GUI_LIB */
+
+/**
+ * Extract red, green and blue values from a string.
+ * This helper function can be used for pasing user strings that specify an RGB colour in the form "r,g,b" in an
+ * input string. It will validate that the string contains three values and that those values are within the range
+ * 0-255, and will return those values or an error indicating that the input string is invalid.
+ *
+ * @date	Wednesday 27-May-2026 3:09 pm, on board Jetstar flight GK335 from Tokyo to Naha
+ * @param	a_colourText	Pointer to the string containing the colour specification in the form "r,g,b"
+ * @param	a_colour		Reference to a variable in which to return the colour as a COLORREF value
+ * @return	KErrNone if the colour was successfully extracted
+ * @return	KErrCorrupt if the input string was invalid
+ */
+
+int RStdTheme::extractColours(const char *a_colourText, COLORREF &a_colour)
+{
+	const char *red, *green, *blue;
+	int redLength, greenLength, blueLength;
+	int redValue, greenValue, blueValue;
+
+	int retVal = KErrCorrupt;
+
+	/* Colour keywords are separated by the ',' character so create and configure a TLex instance for scanning */
+	TLex Lex(a_colourText, (int) strlen(a_colourText));
+
+	Lex.SetWhitespace(" \t,");
+
+	/* Extract the red, green, and blue components */
+	red = Lex.NextToken(&redLength);
+	green = Lex.NextToken(&greenLength);
+	blue = Lex.NextToken(&blueLength);
+
+	if (red != nullptr && green != nullptr && blue != nullptr)
+	{
+		/* Now put the components into std::string instances so that we can use Utils::StringToInt to validate */
+		/* and convert them */
+		std::string redString(red, redLength);
+		std::string greenString(green, greenLength);
+		std::string blueString(blue, blueLength);
+
+		if (Utils::StringToInt(redString.c_str(), &redValue) == KErrNone &&
+			Utils::StringToInt(greenString.c_str(), &greenValue) == KErrNone &&
+			Utils::StringToInt(blueString.c_str(), &blueValue) == KErrNone)
+		{
+			/* All values are correct, so merge them into a single COLORREF */
+			retVal = KErrNone;
+
+			a_colour = RGB(redValue, greenValue, blueValue);
+		}
+	}
+
+	return retVal;
+}
+
+/**
+ * Determine the current OS colour scheme.
+ * Queries the operating system for its current colour scheme, in order to be able to decide whether to use
+ * Brunel's light or dark colour scheme by default.
+ *
+ * @date	Saturday 30-May-2026 07:11 am Best Western Okinawa Kouki Beach balcony
+ * @return	true if a light colour scheme is in use, otherwise false
+ */
+
+bool RStdTheme::lightTheme()
+{
+
+#ifdef __amigaos__
+
+	/* Lock the current screen in order to query its palette values */
+	struct Screen *screen = LockPubScreen(NULL);
+
+	/* Default to light theme if we can't obtain a screen lock */
+	if (!screen)
+	{
+		return true;
+	}
+
+	/* Get background pen and convert it to an RGB value */
+	ULONG rgb = GetRGB4(screen->ViewPort.ColorMap, screen->BlockPen);
+
+	UnlockPubScreen(NULL, screen);
+
+	/* Extract the RGB components from the packed value returned by GetRGB4() */
+	int red = (rgb >> 16) & 0xff;
+	int green = (rgb >> 8) & 0xff;
+	int blue = rgb & 0xff;
+
+	/* Calculate the luminance of the RGB values */
+	int luminance = (red * 299 + green * 587 + blue * 114) / 1000;
+
+	return (luminance >= 128);
+
+#elif defined(QT_GUI_LIB)
+
+	QStyleHints *styleHints = QGuiApplication::styleHints();
+
+	return (styleHints->colorScheme() != Qt::ColorScheme::Dark);
+
+#elif defined(WIN32)
+
+	HKEY key;
+	LONG result = RegOpenKeyExA(HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+		0, KEY_READ, &key);
+
+	/* Default to light theme if we can't open the registry key */
+	if (result != ERROR_SUCCESS)
+	{
+		return true;
+	}
+
+	DWORD value = 1;
+	DWORD size = sizeof(value);
+	RegQueryValueExA(key, "AppsUseLightTheme", nullptr, nullptr, (LPBYTE) &value, &size);
+
+	RegCloseKey(key);
+
+	return (value == 1);
+
+#else /* ! WIN32 */
+
+	return true;
+
+#endif /* ! WIN32 */
+
+}

--- a/StdTheme.h
+++ b/StdTheme.h
@@ -1,0 +1,19 @@
+
+#ifndef STDTHEME_H
+#define STDTHEME_H
+
+/**
+ * A class for determining information about OS colour themes.
+ * Enables the client to determine information such as whether the OS is using a light or dark theme.
+ */
+
+class RStdTheme
+{
+public:
+
+	int extractColours(const char *a_colourText, COLORREF &a_colour);
+
+	bool lightTheme();
+};
+
+#endif /* ! STDTHEME_H */

--- a/StdWindow.h
+++ b/StdWindow.h
@@ -309,6 +309,8 @@ public:
 
 	virtual void Resize(TInt /*a_iOldInnerWidth*/, TInt /*a_iOldInnerHeight*/) { }
 
+	virtual void ThemeChanged() { }
+
 	/* RApplication and CStdGadgetLayout classes need to be able to access this class's internals */
 	/* in order to link windows into the window list and manage the gadgets' positions etc. */
 

--- a/makefile
+++ b/makefile
@@ -39,8 +39,8 @@ ifdef PREFIX
 		$(OBJ)/RemoteFileWatcher.o $(OBJ)/StdApplication.o $(OBJ)/StdCharConverter.o $(OBJ)/StdClipboard.o $(OBJ)/StdConfigFile.o \
 		$(OBJ)/StdCRC.o $(OBJ)/StdDialog.o $(OBJ)/StdExecuter.o $(OBJ)/StdFileRequester.o $(OBJ)/StdFont.o $(OBJ)/StdGadgets.o $(OBJ)/StdGadgetLayout.o \
 		$(OBJ)/StdGadgetSlider.o $(OBJ)/StdGadgetStatusBar.o $(OBJ)/StdGadgetTabPane.o $(OBJ)/StdGadgetTree.o $(OBJ)/StdImage.o $(OBJ)/StdPool.o \
-		$(OBJ)/StdRendezvous.o $(OBJ)/StdSocket.o $(OBJ)/StdStringList.o $(OBJ)/StdTextFile.o $(OBJ)/StdTime.o $(OBJ)/StdWildcard.o $(OBJ)/StdWindow.o \
-		$(OBJ)/Test.o $(OBJ)/Utils.o
+		$(OBJ)/StdRendezvous.o $(OBJ)/StdSocket.o $(OBJ)/StdStringList.o $(OBJ)/StdTextFile.o $(OBJ)/StdTheme.o $(OBJ)/StdTime.o $(OBJ)/StdWildcard.o \
+		$(OBJ)/StdWindow.o $(OBJ)/Test.o $(OBJ)/Utils.o
 
 	ifneq ($(PREFIX), ppc-amigaos-)
 		AUTO_OBJECTS = $(OBJ)/AutoAsl.o $(OBJ)/AutoBitMap.o $(OBJ)/AutoCheckBox.o $(OBJ)/AutoClickTab.o $(OBJ)/AutoDataTypes.o $(OBJ)/AutoDiskfont.o \
@@ -54,7 +54,7 @@ else
 	OBJECTS = $(OBJ)/Args.o $(OBJ)/StdCharConverter.o $(OBJ)/Dir.o $(OBJ)/File.o $(OBJ)/FileUtils.o $(OBJ)/FileWatcher.o $(OBJ)/Lex.o \
 		$(OBJ)/MungWall.o $(OBJ)/RemoteDir.o $(OBJ)/RemoteFactory.o $(OBJ)/RemoteFile.o $(OBJ)/RemoteFileUtils.o $(OBJ)/RemoteFileWatcher.o \
 		$(OBJ)/StdConfigFile.o $(OBJ)/StdCRC.o $(OBJ)/StdExecuter.o $(OBJ)/StdPool.o $(OBJ)/StdRendezvous.o $(OBJ)/StdSocket.o $(OBJ)/StdStringList.o \
-		$(OBJ)/StdTextFile.o $(OBJ)/StdTime.o $(OBJ)/StdWildcard.o $(OBJ)/Test.o $(OBJ)/Utils.o
+		$(OBJ)/StdTextFile.o $(OBJ)/StdTheme.o $(OBJ)/StdTime.o $(OBJ)/StdWildcard.o $(OBJ)/Test.o $(OBJ)/Utils.o
 endif
 
 OBJECTS += $(OBJ)/Handler.o


### PR DESCRIPTION
The colours used by RFont to draw text can now be customised, and support has been added to the CWindow class to enable it to detect light -> dark or dark -> light theme changes, on operating systems that support it.